### PR TITLE
Add missing `NODE_NAME` env var to provider container in daemonset

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -99,8 +99,13 @@ spec:
               name: var-run
         - command:
             - /libvirt-provider
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           image: libvirt-provider:latest
-          name: libvirt-provider
+          name: provider
           securityContext:
             privileged: true
           livenessProbe:


### PR DESCRIPTION
# Proposed Changes

Add missing `NODE_NAME` env var to provider container in daemonset.