### PR TITLE
Reconcile `Machine`s  when `libvirt` VM state changes

### DIFF
--- a/pkg/controllers/machine_controller.go
+++ b/pkg/controllers/machine_controller.go
@@ -293,7 +293,7 @@ func (r *MachineReconciler) processNextWorkItem(ctx context.Context, log logr.Lo
 	defer r.queue.Done(item)
 
 	id := item.(string)
-	log = log.WithValues("machineId", id)
+	log = log.WithValues("machineID", id)
 	ctx = logr.NewContext(ctx, log)
 
 	if err := r.reconcileMachine(ctx, id); err != nil {

--- a/pkg/controllers/machine_controller.go
+++ b/pkg/controllers/machine_controller.go
@@ -270,7 +270,7 @@ func (r *MachineReconciler) startCheckAndEnqueueMachineStatus(ctx context.Contex
 
 			state, err := r.getMachineState(id)
 			if err != nil {
-				log.Error(err, "failed to get machine state", "machine:", id)
+				log.Error(err, "failed to get machine state", "machineID", id)
 				continue
 			}
 

--- a/pkg/controllers/machine_controller.go
+++ b/pkg/controllers/machine_controller.go
@@ -269,7 +269,12 @@ func (r *MachineReconciler) startCheckAndEnqueueMachineState(ctx context.Context
 
 			state, err := r.getMachineState(id)
 			if err != nil {
-				log.Error(err, "failed to get machine state", "machineID", id)
+				if libvirt.IsNotFound(err) {
+					log.V(1).Info("Failed to retrieve domain. Requeueing", "machineID", id)
+					r.queue.AddRateLimited(id)
+				} else {
+					log.Error(err, "failed to get machine state", "machineID", id)
+				}
 				continue
 			}
 


### PR DESCRIPTION
Added functionality to periodically check the libvirt machine state and trigger a reconcile if there is a state mismatch. 

Fixes https://github.com/ironcore-dev/libvirt-provider/issues/102