### PR TITLE
Add logger to `main` package and improve logging

### DIFF
--- a/provider/cmd/app/app.go
+++ b/provider/cmd/app/app.go
@@ -142,6 +142,10 @@ func Command() *cobra.Command {
 			cmd.SetContext(ctrl.LoggerInto(cmd.Context(), ctrl.Log))
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			//flag parsing is done therefore we can silence the usage message
+			cmd.SilenceUsage = true
+			//error logging is done in the main
+			cmd.SilenceErrors = true
 			return Run(cmd.Context(), opts)
 		},
 	}
@@ -242,7 +246,7 @@ func Run(ctx context.Context, opts Options) error {
 		ceph.NewPlugin(),
 		emptydisk.NewPlugin(qcow2Inst, rawInst),
 	}); err != nil {
-		return fmt.Errorf("failed to initialize machine class registry: %w", err)
+		return fmt.Errorf("failed to initialize volume plugin manager: %w", err)
 	}
 
 	nicPlugin, nicPluginCleanup, err := opts.NicPlugin.NetworkInterfacePlugin()
@@ -302,7 +306,7 @@ func Run(ctx context.Context, opts Options) error {
 	setupLog.V(1).Info("Loading machine classes", "Path", opts.PathSupportedMachineClasses)
 	classes, err := mcr.LoadMachineClassesFile(opts.PathSupportedMachineClasses)
 	if err != nil {
-		return fmt.Errorf("failed to initialize machine class registry: %w", err)
+		return fmt.Errorf("failed to load machine classes: %w", err)
 	}
 
 	machineClasses, err := mcr.NewMachineClassRegistry(classes)

--- a/provider/cmd/app/app.go
+++ b/provider/cmd/app/app.go
@@ -391,7 +391,7 @@ func runGRPCServer(ctx context.Context, setupLog logr.Logger, log logr.Logger, s
 
 	grpcSrv := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
-			commongrpc.InjectLogger(log.WithName("grpc-server")),
+			commongrpc.InjectLogger(log.WithName("iri-server")),
 			commongrpc.LogRequest,
 		),
 	)

--- a/provider/cmd/main.go
+++ b/provider/cmd/main.go
@@ -15,7 +15,7 @@ func main() {
 	log := ctrl.Log.WithName("main")
 
 	if err := app.Command().ExecuteContext(ctx); err != nil {
-		log.V(1).Error(err, "Error running libvirt provider")
+		log.V(1).Error(err, "error running libvirt provider")
 		os.Exit(1)
 	}
 }

--- a/provider/cmd/main.go
+++ b/provider/cmd/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/ironcore-dev/libvirt-provider/provider/cmd/app"
@@ -13,9 +12,10 @@ import (
 
 func main() {
 	ctx := ctrl.SetupSignalHandler()
+	log := ctrl.Log.WithName("main")
 
 	if err := app.Command().ExecuteContext(ctx); err != nil {
-		fmt.Println(err.Error())
+		log.V(1).Error(err, "Error running libvirt provider")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
# Proposed Changes

Improved logging
- Replaced main error logging from `fmt.Println` to logger
- Removed redundant logging by logger and cobra
- Disabled usage help once the flags are parsed 

Fixes #85 