### PR TITLE
Fix `NetworkInterface` status propagation for IPs

### DIFF
--- a/pkg/api/machine.go
+++ b/pkg/api/machine.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"net"
 	"time"
 )
 
@@ -97,7 +96,7 @@ type NetworkInterfaceStatus struct {
 	Name   string                `json:"name"`
 	Handle string                `json:"handle"`
 	State  NetworkInterfaceState `json:"state"`
-	IPs    []net.IP              `json:"ips"`
+	IPs    []string              `json:"ips"`
 }
 
 type NetworkInterfaceState string

--- a/pkg/controllers/machine_controller_nics.go
+++ b/pkg/controllers/machine_controller_nics.go
@@ -172,6 +172,7 @@ func (r *MachineReconciler) attachDetachNetworkInterfaces(
 				Name:   nicName,
 				Handle: mountedNic.networkInterface.Handle,
 				State:  api.NetworkInterfaceStateAttached,
+				IPs:    desiredNic.Ips,
 			})
 		}
 	}

--- a/pkg/plugins/networkinterface/plugins.go
+++ b/pkg/plugins/networkinterface/plugins.go
@@ -6,7 +6,6 @@ package networkinterface
 import (
 	"context"
 	"fmt"
-	"net"
 
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
@@ -101,7 +100,7 @@ type NetworkInterface struct {
 	HostDevice      *HostDevice
 	Isolated        *Isolated
 	ProviderNetwork *ProviderNetwork
-	IPs             []net.IP
+	IPs             []string
 }
 
 type Isolated struct{}

--- a/provider/server/machine.go
+++ b/provider/server/machine.go
@@ -138,15 +138,11 @@ func (s *Server) getIRINICStatus(machine *api.Machine) ([]*iri.NetworkInterfaceS
 			return nil, fmt.Errorf("failed to get nic state: %w", err)
 		}
 
-		nicIPs := make([]string, 0, len(nic.IPs))
-		for _, ip := range nic.IPs {
-			nicIPs = append(nicIPs, ip.String())
-		}
 		nics = append(nics, &iri.NetworkInterfaceStatus{
 			Name:   nic.Name,
 			Handle: nic.Handle,
 			State:  state,
-			Ips:    nicIPs,
+			Ips:    nic.IPs,
 		})
 	}
 


### PR DESCRIPTION
# Proposed Changes

Fix `NetworkInterface` status propagation for IPs:
- Switch to `[]string` for IPs in `NetworkInterface` status
- Fix update/create domain and propagate correct IPs in the NIC status
- Fix early exit for existing domains to propagate IPs in the NIC status