### PR TITLE
Enhance Workflow Stability: Update Microceph Workflow to `quincy/stable` Channel

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -x
           
-          sudo snap install microceph --channel=latest/stable
+          sudo snap install microceph --channel=quincy/stable
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ceph-common
           sudo microceph cluster bootstrap


### PR DESCRIPTION
This PR enhances the stability of our Microceph workflow by switching to the `quincy/stable` channel from `latest/stable`. By making this change, we reduce the chance of running into problems caused by the latest updates or bugs.