### PR TITLE
Set `ResyncIntervalVolumeSize` in integration tests

### DIFF
--- a/provider/server/server_suite_test.go
+++ b/provider/server/server_suite_test.go
@@ -109,6 +109,7 @@ var _ = BeforeSuite(func() {
 		NicPlugin:                      pluginOpts,
 		GCVMGracefulShutdownTimeout:    10 * time.Second,
 		ResyncIntervalGarbageCollector: 5 * time.Second,
+		ResyncIntervalVolumeSize:       1 * time.Minute,
 	}
 
 	srvCtx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Since the default value of ResyncIntervalVolumeSize is now set in the flags, and the integration tests start from the Run() function, its default value must be specified in integrations to prevent frequent operation of the goroutine responsible for volume resize. This behavior is causing unexpected behavior in integration tests.