### PR TITLE
stop rewrite DeletedAt for every call

### DIFF
--- a/pkg/host/store.go
+++ b/pkg/host/store.go
@@ -165,14 +165,16 @@ func (s *Store[E]) Delete(_ context.Context, id string) error {
 		return s.delete(id)
 	}
 
-	if obj.GetDeletedAt() == nil {
-		now := time.Now()
-		obj.SetDeletedAt(&now)
-		obj.IncrementResourceVersion()
+	if obj.GetDeletedAt() != nil {
+		return nil
+	}
 
-		if _, err := s.set(obj); err != nil {
-			return fmt.Errorf("failed to set object metadata: %w", err)
-		}
+	now := time.Now()
+	obj.SetDeletedAt(&now)
+	obj.IncrementResourceVersion()
+
+	if _, err := s.set(obj); err != nil {
+		return fmt.Errorf("failed to set object metadata: %w", err)
 	}
 
 	s.enqueue(store.WatchEvent[E]{

--- a/pkg/host/store.go
+++ b/pkg/host/store.go
@@ -165,12 +165,14 @@ func (s *Store[E]) Delete(_ context.Context, id string) error {
 		return s.delete(id)
 	}
 
-	now := time.Now()
-	obj.SetDeletedAt(&now)
-	obj.IncrementResourceVersion()
+	if obj.GetDeletedAt() == nil {
+		now := time.Now()
+		obj.SetDeletedAt(&now)
+		obj.IncrementResourceVersion()
 
-	if _, err := s.set(obj); err != nil {
-		return fmt.Errorf("failed to set object metadata: %w", err)
+		if _, err := s.set(obj); err != nil {
+			return fmt.Errorf("failed to set object metadata: %w", err)
+		}
 	}
 
 	s.enqueue(store.WatchEvent[E]{


### PR DESCRIPTION
# Proposed Changes

DeletdeAt in api.Machine was rewrite for every iri call DeleteMachine. It created conflicts with other components which trying update api.Machine object and information when deleteMachine call was called first time was lost.

