### PR TITLE
Removing `virsh` dependency

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,11 +20,11 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      
+
       - name: Setup MicroCeph
         run: |
           set -x
-          
+
           sudo snap install microceph --channel=quincy/stable
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y ceph-common
@@ -37,7 +37,7 @@ jobs:
           for flag in nosnaptrim noscrub nobackfill norebalance norecover noscrub nodeep-scrub; do
               sudo microceph.ceph osd set $flag
           done
-          
+
           # Repurpose the ephemeral disk for ceph OSD.
           sudo swapoff /mnt/swapfile
           ephemeral_disk="$(findmnt --noheadings --output SOURCE --target /mnt | sed 's/[0-9]\+$//')"
@@ -45,9 +45,9 @@ jobs:
           sudo rm -rf /etc/ceph
           sudo ln -s /var/snap/microceph/current/conf/ /etc/ceph
           sudo microceph enable rgw
-          
+
           sudo ceph osd pool create devpool 8
-          
+
           # Wait until there are no more "unkowns" pgs
           for _ in $(seq 60); do
             if sudo microceph.ceph pg stat | grep -wF unknown; then
@@ -60,7 +60,7 @@ jobs:
           sudo rbd create --size 5000 --pool devpool test-img
           sudo rm -f /snap/bin/rbd
           sudo chmod 644 /etc/ceph/ceph.client.admin.keyring
-      
+
       - name: Set Environment Variables
         run: |
           echo "CEPH_MONITORS=$(hostname):6789" >> $GITHUB_ENV
@@ -78,11 +78,15 @@ jobs:
           librbd-dev librados-dev libc-bin gcc
           sudo apt-get install -y qemu-kvm libvirt-daemon-system
           sudo systemctl enable --now libvirtd
-          sudo usermod -aG kvm,libvirt $USER
+          sudo usermod -aG kvm,libvirt,tty $USER
           sudo usermod -aG $(id -gn $USER) libvirt-qemu
           sudo setfacl -m user:$USER:rw /var/run/libvirt/libvirt-sock
           sudo update-ca-certificates
           sudo rm -rf /var/lib/apt/lists
+          sudo sed -i '$a\ devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=0660 0 0' /etc/fstab
+          sudo mount -o remount /dev/pts
+
 
       - name: Run integration tests
-        run: make integration-tests
+        # Starting a new instance of the Bash shell to reflect the added permissions
+        run: sudo -H -E -u $USER bash -c 'make integration-tests'

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -82,24 +82,24 @@
     Sample `iri-machine.yaml`:
 
     ```yaml
-        metadata:
-          id: 91076287116041d00fd421f43c3760389041dac4a8bd9201afba9a5baeb21c7
-          labels:
-            downward-api.machinepoollet.api.onmetal.de/root-machine-name: machine-hd4
-            downward-api.machinepoollet.api.onmetal.de/root-machine-namespace: default
-            downward-api.machinepoollet.api.onmetal.de/root-machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
-            machinepoollet.api.onmetal.de/machine-name: machine-hd4
-            machinepoollet.api.onmetal.de/machine-namespace: default
-            machinepoollet.api.onmetal.de/machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
-        spec:
-          class: x3-small
-          image:
-            image: ghcr.io/ironcore-dev/ironcore-image/gardenlinux:rootfs-dev-20231206-v1
-          volumes:
-          - empty_disk:
-              size_bytes: 5368709120
-            name: ephe-disk
-            device: oda
+    metadata:
+      id: 91076287116041d00fd421f43c3760389041dac4a8bd9201afba9a5baeb21c7
+      labels:
+        downward-api.machinepoollet.api.onmetal.de/root-machine-name: machine-hd4
+        downward-api.machinepoollet.api.onmetal.de/root-machine-namespace: default
+        downward-api.machinepoollet.api.onmetal.de/root-machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
+        machinepoollet.api.onmetal.de/machine-name: machine-hd4
+        machinepoollet.api.onmetal.de/machine-namespace: default
+        machinepoollet.api.onmetal.de/machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
+    spec:
+      class: x3-small
+      image:
+        image: ghcr.io/ironcore-dev/ironcore-image/gardenlinux:rootfs-dev-20231206-v1
+      volumes:
+      - empty_disk:
+          size_bytes: 5368709120
+        name: ephe-disk
+        device: oda
     ```
 
 1. **Listing machines**

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -7,7 +7,7 @@
 - [Deploy `libvirt-provider`](#deploy-libvirt-provider)
 
 > ℹ️ **NOTE**:</br>
-> To be able to take exec console of the machine, you can follow either of the below approaches:</br>
+> To be able to take exec console of the machine, you can follow any one of the below approaches:</br>
 > - Run the `libvirt-provider` as the `libvirt-qemu` user.</br>
 > - Create an entry with `devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=0660 0 0` in `/etc/fstab`.</br>
 > - Manually ensure that you have `0660` access permissions on the character files created in `/dev/pts`.</br>
@@ -17,7 +17,6 @@
 - Linux (code contains OS specific code)
 - go >= 1.20
 - `git`, `make` and `kubectl`
-- [Kustomize](https://kustomize.io/)
 - Access to a Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/), [kind](https://kind.sigs.k8s.io/) or a
   real cluster)
 - [libvirt](http://libvirt.org)
@@ -28,110 +27,98 @@
 
 ### Setup `irictl-machine`
 
-**1. Clone ironcore repository**
+1. **Clone ironcore repository**
 
-```bash
-git clone git@github.com:ironcore-dev/ironcore.git
-cd ironcore
-```
+    ```bash
+    git clone git@github.com:ironcore-dev/ironcore.git
+    cd ironcore
+    ```
 
-**2. Build `irictl-machine`**
+2. **Build `irictl-machine`**
 
-```bash
-go build -o bin/irictl-machine ./irictl-machine/cmd/irictl-machine/main.go
-```
+    ```bash
+    go build -o bin/irictl-machine ./irictl-machine/cmd/irictl-machine/main.go
+    ```
 
 ## Run libvirt-provider for local development
 
-**1. Clone the Repository**
+1. **Clone the Repository**
 
-To bring up and start locally the libvirt-provider project for development purposes you first need to clone the repository.
+    To bring up and start locally the libvirt-provider project for development purposes you first need to clone the repository.
 
-```bash
-git clone git@github.com:ironcore-dev/libvirt-provider.git
-cd libvirt-provider
-```
+    ```bash
+    git clone git@github.com:ironcore-dev/libvirt-provider.git
+    cd libvirt-provider
+    ```
 
-**2. Build the `libvirt-provider`**
+1. **Build the `libvirt-provider`**
 
-```bash
-make build
-```
+    ```bash
+    make build
+    ```
 
-**3. Run the `libvirt-provider`**
+1. **Run the `libvirt-provider`**
    
-The required libvirt-provider flags needs to be defined:
+    The required libvirt-provider flags needs to be defined:
 
-```bash
-go run provider/cmd/main.go \
-   --libvirt-provider-dir=<path-to-initialize-libvirt-provider> \
-   --supported-machine-classes=<path-to-machine-class-json>/machine-classes.json \
-   --network-interface-plugin-name=isolated \
-   --address=<local-path>/iri-machinebroker.sock
-```
+    ```bash
+    go run provider/cmd/main.go \
+      --libvirt-provider-dir=<path-to-initialize-libvirt-provider> \
+      --supported-machine-classes=<path-to-machine-class-json>/machine-classes.json \
+      --network-interface-plugin-name=isolated \
+      --address=<local-path>/iri-machinebroker.sock
+    ```
 
-Sample `machine-classes.json`:
-
-```json
-[
-    {
-        "name": "x3-small",
-        "capabilities": {
-            "cpu_millis": 500,
-            "memory_bytes": 256
-        }
-    }
-]
-```
+    Sample `machine-classes.json` can be found [here](../../config/development/machineclasses.json).
 
 ## Interact with the `libvirt-provider`
 
-**1. Creating machine**
+1. **Creating machine**
 
-```bash
-irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock create machine -f <path-to-machine-yaml>/iri-machine.yaml
-```
+    ```bash
+    irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock create machine -f <path-to-machine-yaml>/iri-machine.yaml
+    ```
 
-Sample `iri-machine.yaml`:
+    Sample `iri-machine.yaml`:
 
-```yaml
-metadata:
-  id: 91076287116041d00fd421f43c3760389041dac4a8bd9201afba9a5baeb21c7
-  labels:
-    downward-api.machinepoollet.api.onmetal.de/root-machine-name: machine-hd4
-    downward-api.machinepoollet.api.onmetal.de/root-machine-namespace: default
-    downward-api.machinepoollet.api.onmetal.de/root-machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
-    machinepoollet.api.onmetal.de/machine-name: machine-hd4
-    machinepoollet.api.onmetal.de/machine-namespace: default
-    machinepoollet.api.onmetal.de/machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
-spec:
-  class: x3-small
-  image:
-    image: ghcr.io/ironcore-dev/ironcore-image/gardenlinux:rootfs-dev-20231206-v1
-  volumes:
-  - empty_disk:
-      size_bytes: 5368709120
-    name: ephe-disk
-    device: oda
-```
+    ```yaml
+        metadata:
+          id: 91076287116041d00fd421f43c3760389041dac4a8bd9201afba9a5baeb21c7
+          labels:
+            downward-api.machinepoollet.api.onmetal.de/root-machine-name: machine-hd4
+            downward-api.machinepoollet.api.onmetal.de/root-machine-namespace: default
+            downward-api.machinepoollet.api.onmetal.de/root-machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
+            machinepoollet.api.onmetal.de/machine-name: machine-hd4
+            machinepoollet.api.onmetal.de/machine-namespace: default
+            machinepoollet.api.onmetal.de/machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
+        spec:
+          class: x3-small
+          image:
+            image: ghcr.io/ironcore-dev/ironcore-image/gardenlinux:rootfs-dev-20231206-v1
+          volumes:
+          - empty_disk:
+              size_bytes: 5368709120
+            name: ephe-disk
+            device: oda
+    ```
 
-**2. Listing machines**
+2. **Listing machines**
 
-```bash
-irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock get machine
-```
+    ```bash
+    irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock get machine
+    ```
 
-**3. Deleting machine**
+3. **Deleting machine**
 
-```bash
-irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock delete machine <machine UUID>
-```
+    ```bash
+    irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock delete machine <machine UUID>
+    ```
 
-**4. Taking machine console**
+4. **Taking machine console**
 
-```bash
-irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock exec <machine UUID>
-```
+    ```bash
+    irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock exec <machine UUID>
+    ```
 
 ## Deploy `libvirt-provider`
 
@@ -142,15 +129,15 @@ irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock exec
 > ℹ️ **NOTE**:</br>
 > Libvirt-provider can run directly as binary program on worker node
 
-**1. Make docker images**
+1. **Make docker images**
 
-```bash
-make docker-build
-```
+    ```bash
+    make docker-build
+    ```
 
-**2. Deploy virtlet as kubernetes**
+2. **Deploy virtlet as kubernetes**
 
-```bash
-make deploy
-```
+    ```bash
+    make deploy
+    ```
     

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,0 +1,156 @@
+# Local Development Setup
+
+- [Prerequisites](#prerequisites)
+- [Preperation](#preperation)
+- [Run libvirt-provider for local development](#run-libvirt-provider-for-local-development)
+- [Interact with the `libvirt-provider`](#interact-with-the-libvirt-provider)
+- [Deploy `libvirt-provider`](#deploy-libvirt-provider)
+
+> ℹ️ **NOTE**:</br>
+> To be able to take exec console of the machine, you can follow either of the below approaches:</br>
+> - Run the `libvirt-provider` as the `libvirt-qemu` user.</br>
+> - Create an entry with `devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=0660 0 0` in `/etc/fstab`.</br>
+> - Manually ensure that you have `0660` access permissions on the character files created in `/dev/pts`.</br>
+
+## Prerequisites
+
+- Linux (code contains OS specific code)
+- go >= 1.20
+- `git`, `make` and `kubectl`
+- [Kustomize](https://kustomize.io/)
+- Access to a Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/), [kind](https://kind.sigs.k8s.io/) or a
+  real cluster)
+- [libvirt](http://libvirt.org)
+- [QEMU](https://www.qemu.org/download/)
+- `irictl-machine` should be running locally or as [container](https://github.com/ironcore-dev/ironcore/pkgs/container/ironcore-irictl-machine)
+
+## Preperation
+
+### Setup `irictl-machine`
+
+**1. Clone ironcore repository**
+
+```bash
+git clone git@github.com:ironcore-dev/ironcore.git
+cd ironcore
+```
+
+**2. Build `irictl-machine`**
+
+```bash
+go build -o bin/irictl-machine ./irictl-machine/cmd/irictl-machine/main.go
+```
+
+## Run libvirt-provider for local development
+
+**1. Clone the Repository**
+
+To bring up and start locally the libvirt-provider project for development purposes you first need to clone the repository.
+
+```bash
+git clone git@github.com:ironcore-dev/libvirt-provider.git
+cd libvirt-provider
+```
+
+**2. Build the `libvirt-provider`**
+
+```bash
+make build
+```
+
+**3. Run the `libvirt-provider`**
+   
+The required libvirt-provider flags needs to be defined:
+
+```bash
+go run provider/cmd/main.go \
+   --libvirt-provider-dir=<path-to-initialize-libvirt-provider> \
+   --supported-machine-classes=<path-to-machine-class-json>/machine-classes.json \
+   --network-interface-plugin-name=isolated \
+   --address=<local-path>/iri-machinebroker.sock
+```
+
+Sample `machine-classes.json`:
+
+```json
+[
+    {
+        "name": "x3-small",
+        "capabilities": {
+            "cpu_millis": 500,
+            "memory_bytes": 256
+        }
+    }
+]
+```
+
+## Interact with the `libvirt-provider`
+
+**1. Creating machine**
+
+```bash
+irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock create machine -f <path-to-machine-yaml>/iri-machine.yaml
+```
+
+Sample `iri-machine.yaml`:
+
+```yaml
+metadata:
+  id: 91076287116041d00fd421f43c3760389041dac4a8bd9201afba9a5baeb21c7
+  labels:
+    downward-api.machinepoollet.api.onmetal.de/root-machine-name: machine-hd4
+    downward-api.machinepoollet.api.onmetal.de/root-machine-namespace: default
+    downward-api.machinepoollet.api.onmetal.de/root-machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
+    machinepoollet.api.onmetal.de/machine-name: machine-hd4
+    machinepoollet.api.onmetal.de/machine-namespace: default
+    machinepoollet.api.onmetal.de/machine-uid: cab82eac-09d8-4428-9e6c-c98b40027b74
+spec:
+  class: x3-small
+  image:
+    image: ghcr.io/ironcore-dev/ironcore-image/gardenlinux:rootfs-dev-20231206-v1
+  volumes:
+  - empty_disk:
+      size_bytes: 5368709120
+    name: ephe-disk
+    device: oda
+```
+
+**2. Listing machines**
+
+```bash
+irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock get machine
+```
+
+**3. Deleting machine**
+
+```bash
+irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock delete machine <machine UUID>
+```
+
+**4. Taking machine console**
+
+```bash
+irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock exec <machine UUID>
+```
+
+## Deploy `libvirt-provider`
+
+> ℹ️ **NOTE**:</br>
+> If the `libvirt-uri` can not be auto-detected it can be defined via flag: e.g. `--libvirt-uri=qemu:///session`</br>
+> ℹ️ **NOTE**:</br>
+> For trying out the controller use the `isolated` network interface plugin: `--network-interface-plugin-name=isolated`</br>
+> ℹ️ **NOTE**:</br>
+> Libvirt-provider can run directly as binary program on worker node
+
+**1. Make docker images**
+
+```bash
+make docker-build
+```
+
+**2. Deploy virtlet as kubernetes**
+
+```bash
+make deploy
+```
+    

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -34,7 +34,7 @@
     cd ironcore
     ```
 
-2. **Build `irictl-machine`**
+1. **Build `irictl-machine`**
 
     ```bash
     go build -o bin/irictl-machine ./irictl-machine/cmd/irictl-machine/main.go
@@ -102,19 +102,19 @@
             device: oda
     ```
 
-2. **Listing machines**
+1. **Listing machines**
 
     ```bash
     irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock get machine
     ```
 
-3. **Deleting machine**
+1. **Deleting machine**
 
     ```bash
     irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock delete machine <machine UUID>
     ```
 
-4. **Taking machine console**
+1. **Taking machine console**
 
     ```bash
     irictl-machine --address=unix:<local-path-to-socket>/iri-machinebroker.sock exec <machine UUID>
@@ -135,7 +135,7 @@
     make docker-build
     ```
 
-2. **Deploy virtlet as kubernetes**
+1. **Deploy virtlet as kubernetes**
 
     ```bash
     make deploy

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -9,7 +9,7 @@
 > ℹ️ **NOTE**:</br>
 > To be able to take exec console of the machine, you can follow any one of the below approaches:</br>
 > - Run the `libvirt-provider` as the `libvirt-qemu` user.</br>
-> - Create an entry with `devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=0660 0 0` in `/etc/fstab`.</br>
+> - Add user to `tty` group and create an entry with `devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=0660 0 0` in `/etc/fstab`.</br>
 > - Manually ensure that you have `0660` access permissions on the character files created in `/dev/pts`.</br>
 
 ## Prerequisites

--- a/provider/cmd/app/app.go
+++ b/provider/cmd/app/app.go
@@ -86,8 +86,6 @@ type Options struct {
 
 	GCVMGracefulShutdownTimeout    time.Duration
 	ResyncIntervalGarbageCollector time.Duration
-
-	VirshExecutable string
 }
 
 type LibvirtOptions struct {
@@ -113,8 +111,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.StreamingAddress, "streaming-address", "127.0.0.1:20251", "Address to run the streaming server on")
 	fs.StringVar(&o.BaseURL, "base-url", "", "The base url to construct urls for streaming from. If empty it will be "+
 		"constructed from the streaming-address")
-
-	fs.StringVar(&o.VirshExecutable, "virsh-executable", "virsh", "Path / name of the virsh executable.")
 
 	fs.BoolVar(&o.EnableHugepages, "enable-hugepages", false, "Enable using Hugepages.")
 	fs.Var(&o.GuestAgent, "guest-agent-type", fmt.Sprintf("Guest agent implementation to use. Available: %v", guestAgentOptionAvailable()))
@@ -343,7 +339,6 @@ func Run(ctx context.Context, opts Options) error {
 		MachineClasses:  machineClasses,
 		VolumePlugins:   volumePlugins,
 		NetworkPlugins:  nicPlugin,
-		VirshExecutable: opts.VirshExecutable,
 		EnableHugepages: opts.EnableHugepages,
 		GuestAgent:      opts.GuestAgent.GetAPIGuestAgent(),
 	})

--- a/provider/server/exec.go
+++ b/provider/server/exec.go
@@ -9,12 +9,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os/exec"
-	"strings"
+	"os"
 	"sync"
 	"time"
 
-	"github.com/creack/pty"
 	"github.com/digitalocean/go-libvirt"
 	"github.com/go-logr/logr"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
@@ -26,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/tools/remotecommand"
+	"libvirt.org/go/libvirtxml"
 )
 
 const (
@@ -115,7 +114,7 @@ func (e executorExec) Exec(ctx context.Context, in io.Reader, out io.WriteCloser
 		return fmt.Errorf("apiMachine %w in the store", store.ErrNotFound)
 	}
 
-	_, err := e.Libvirt.DomainLookupByUUID(libvirtutils.UUIDStringToBytes(machineID))
+	domain, err := e.Libvirt.DomainLookupByUUID(libvirtutils.UUIDStringToBytes(machineID))
 	if err != nil {
 		if !libvirtutils.IsErrorCode(err, libvirt.ErrNoDomain) {
 			return fmt.Errorf("error looking up domain: %w", err)
@@ -124,16 +123,21 @@ func (e executorExec) Exec(ctx context.Context, in io.Reader, out io.WriteCloser
 		return fmt.Errorf("machine %s has not yet been synced", machineID)
 	}
 
-	uri, err := e.Libvirt.ConnectGetUri()
+	domainXMLData, err := e.Libvirt.DomainGetXMLDesc(domain, 0)
 	if err != nil {
-		return fmt.Errorf("error getting connection uri")
+		return fmt.Errorf("failed to lookup domain: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, e.VirshExecutable, "-c", strings.TrimSpace(uri), "console", machineID)
+	domainXML := &libvirtxml.Domain{}
+	if err := domainXML.Unmarshal(domainXMLData); err != nil {
+		return fmt.Errorf("failed to unmarshal domain: %w", err)
+	}
 
-	f, err := pty.Start(cmd)
+	ttyPath := domainXML.Devices.Consoles[0].TTY
+
+	f, err := os.OpenFile(ttyPath, os.O_RDWR, 0)
 	if err != nil {
-		return fmt.Errorf("error starting command: %w", err)
+		return fmt.Errorf("error opening PTY: %w", err)
 	}
 
 	// Wrap the input stream with an escape proxy. Escape Sequence Ctrl + ] = 29
@@ -149,7 +153,7 @@ func (e executorExec) Exec(ctx context.Context, in io.Reader, out io.WriteCloser
 			n, err := inputReader.Read(buf)
 			if err != nil {
 				if _, ok := err.(term.EscapeError); ok {
-					_, _ = f.Write(buf) // This is to close the writer.
+					f.Close() // This is to close the writer.
 					log.Info("Closed reading the terminal. Escape sequence received")
 					return
 				}
@@ -172,11 +176,6 @@ func (e executorExec) Exec(ctx context.Context, in io.Reader, out io.WriteCloser
 		_, _ = io.Copy(out, f)
 		log.Info("Closed writing to the terminal")
 	}()
-
-	if err := cmd.Wait(); err != nil {
-		// Avoid returning so that the function can verify if all go routines are terminated.
-		log.Error(err, "console command interrupted")
-	}
 
 	wg.Wait()
 	log.Info("Closed console for the machine")

--- a/provider/server/exec.go
+++ b/provider/server/exec.go
@@ -107,11 +107,11 @@ func (e executorExec) Exec(ctx context.Context, in io.Reader, out io.WriteCloser
 	machineID := e.ExecRequest.MachineId
 
 	// Check if a console is already active for this machine
-	if _, ok := activeConsoles.Load(machineID); ok {
+	_, loaded := activeConsoles.LoadOrStore(machineID, true)
+	if loaded {
 		return errors.New("operation failed: Active console session exists for this domain")
 	}
 
-	activeConsoles.Store(machineID, true)
 	defer activeConsoles.Delete(machineID)
 
 	// Check if the apiMachine doesn't exist, to avoid making the libvirt-lookup call.

--- a/provider/server/server.go
+++ b/provider/server/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"sync"
 
 	"github.com/digitalocean/go-libvirt"
 	"github.com/go-logr/logr"
@@ -38,6 +39,7 @@ type Server struct {
 	machineClasses MachineClassRegistry
 
 	execRequestCache request.Cache[*iri.ExecRequest]
+	activeConsoles   sync.Map
 	libvirt          *libvirt.Libvirt
 
 	enableHugepages bool
@@ -88,6 +90,7 @@ func New(opts Options) (*Server, error) {
 		enableHugepages:        opts.EnableHugepages,
 		guestAgent:             opts.GuestAgent,
 		execRequestCache:       request.NewCache[*iri.ExecRequest](),
+		activeConsoles:         sync.Map{},
 	}, nil
 }
 

--- a/provider/server/server.go
+++ b/provider/server/server.go
@@ -39,7 +39,6 @@ type Server struct {
 
 	execRequestCache request.Cache[*iri.ExecRequest]
 	libvirt          *libvirt.Libvirt
-	virshExecutable  string
 
 	enableHugepages bool
 
@@ -50,8 +49,7 @@ type Options struct {
 	// BaseURL is the base URL in form http(s)://host:port/path?query to produce request URLs relative to.
 	BaseURL string
 
-	Libvirt         *libvirt.Libvirt
-	VirshExecutable string
+	Libvirt *libvirt.Libvirt
 
 	IDGen idgen.IDGen
 
@@ -83,7 +81,6 @@ func New(opts Options) (*Server, error) {
 		baseURL:                baseURL,
 		idGen:                  opts.IDGen,
 		libvirt:                opts.Libvirt,
-		virshExecutable:        opts.VirshExecutable,
 		machineStore:           opts.MachineStore,
 		volumePlugins:          opts.VolumePlugins,
 		networkInterfacePlugin: opts.NetworkPlugins,

--- a/provider/server/server_suite_test.go
+++ b/provider/server/server_suite_test.go
@@ -117,7 +117,6 @@ var _ = BeforeSuite(func() {
 		GCVMGracefulShutdownTimeout:    gracefulShutdownTimeout,
 		ResyncIntervalGarbageCollector: resyncGarbageCollectorInterval,
 		ResyncIntervalVolumeSize:       resyncVolumeSizeInterval,
-		VirshExecutable:                "virsh",
 		GuestAgent:                     app.GuestAgentOption(api.GuestAgentNone),
 	}
 


### PR DESCRIPTION
# Proposed Changes

- Using Pseudo-Terminal (pty) for bi-directional communication
- Created development setup document and mentioned about the needed access.

Fixes https://github.com/ironcore-dev/libvirt-provider/issues/71