### PR TITLE
Removed `dd` dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ FROM busybox:1.36.1-uclibc as busybox
 FROM distroless-$TARGETARCH  as libvirt-provider
 WORKDIR /
 COPY --from=busybox /bin/sh /bin/sh
-COPY --from=busybox /bin/dd /bin/dd
 COPY --from=busybox /bin/mkdir /bin/mkdir
 COPY --from=builder /lib/${LIB_DIR_PREFIX}-linux-gnu/librados.so.2 \
 /lib/${LIB_DIR_PREFIX}-linux-gnu/librbd.so.1 \

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -44,22 +44,22 @@ func (Exec) Create(filename string, opts ...CreateOption) error {
 }
 
 func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error {
-	log = log.WithName("createEmptyFileWithSeek")
+	log = log.WithName("createEmptyFileWithSeek").WithValues("filename", filename)
 	dstFile, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed opening destination file: %w", err)
 	}
 
 	defer func() {
 		destErr := dstFile.Close()
 		if destErr != nil {
-			log.Error(destErr, "error closing file", "Path", dstFile)
+			log.Error(destErr, "error closing file")
 		}
 	}()
 
 	_, err = dstFile.Seek(seek, io.SeekStart)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed seeking destination file: %w", err)
 	}
 
 	_, err = dstFile.Write([]byte{0})
@@ -68,27 +68,27 @@ func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error
 }
 
 func copyFile(log logr.Logger, src, dst string) error {
-	log = log.WithName("copyFile")
+	log = log.WithName("copyFile").WithValues("source", src, "destination", dst)
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed opening source file: %w", err)
 	}
 	defer func() {
 		srcErr := srcFile.Close()
 		if srcErr != nil {
-			log.Error(srcErr, "error closing file", "Path", srcFile)
+			log.Error(srcErr, "error closing source file")
 		}
 	}()
 
 	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed opening destination file: %w", err)
 	}
 
 	defer func() {
 		destErr := dstFile.Close()
 		if destErr != nil {
-			log.Error(destErr, "error closing file", "Path", dstFile)
+			log.Error(destErr, "error closing destination file")
 		}
 	}()
 

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -31,12 +31,12 @@ func (Exec) Create(filename string, opts ...CreateOption) error {
 		// to ensure that data is written at the exact byte position specified by seek.
 		err := createEmptyFileWithSeek(log, filename, seek-1)
 		if err != nil {
-			return fmt.Errorf("failed creating the empty ephemeral disk: %w", err)
+			return fmt.Errorf("failed creating the empty ephemeral disk %s: %w", filename, err)
 		}
 	} else {
 		err := copyFile(log, o.SourceFile, filename)
 		if err != nil {
-			return fmt.Errorf("failed creating the image for virtual disk: %w", err)
+			return fmt.Errorf("failed creating virtual disk image, source: %s, destination: %s: %w", o.SourceFile, filename, err)
 		}
 	}
 
@@ -71,7 +71,7 @@ func copyFile(log logr.Logger, src, dst string) error {
 	log = log.WithName("copyFile").WithValues("source", src, "destination", dst)
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed opening source file: %w", err)
+		return fmt.Errorf("failed opening source file %s: %w", src, err)
 	}
 	defer func() {
 		srcErr := srcFile.Close()
@@ -82,7 +82,7 @@ func copyFile(log logr.Logger, src, dst string) error {
 
 	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
 	if err != nil {
-		return fmt.Errorf("failed opening destination file: %w", err)
+		return fmt.Errorf("failed opening destination file %s: %w", dst, err)
 	}
 
 	defer func() {

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -50,9 +50,8 @@ func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error
 	}
 
 	defer func() {
-		destErr := dstFile.Close()
-		if destErr != nil {
-			log.Error(destErr, "error closing file in createEmptyFileWithSeek")
+		if err := dstFile.Close(); err != nil {
+			log.Error(err, "error closing file in createEmptyFileWithSeek")
 		}
 	}()
 

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -15,7 +15,7 @@ import (
 
 type Exec struct{}
 
-const filePerm = 0640
+const filePerm = 0660
 
 func (Exec) Create(filename string, opts ...CreateOption) error {
 	o := &CreateOptions{}
@@ -31,7 +31,7 @@ func (Exec) Create(filename string, opts ...CreateOption) error {
 		// to ensure that data is written at the exact byte position specified by seek.
 		err := createEmptyFileWithSeek(log, filename, seek-1)
 		if err != nil {
-			return fmt.Errorf("failed creating the empty ephemeral disk %s: %w", filename, err)
+			return fmt.Errorf("failed creating the empty ephemeral disk at %s: %w", filename, err)
 		}
 	} else {
 		err := copyFile(log, o.SourceFile, filename)
@@ -71,7 +71,7 @@ func copyFile(log logr.Logger, src, dst string) error {
 	log = log.WithName("copyFile").WithValues("source", src, "destination", dst)
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed opening source file %s: %w", src, err)
+		return fmt.Errorf("failed opening source file: %w", err)
 	}
 	defer func() {
 		srcErr := srcFile.Close()
@@ -82,7 +82,7 @@ func copyFile(log logr.Logger, src, dst string) error {
 
 	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
 	if err != nil {
-		return fmt.Errorf("failed opening destination file %s: %w", dst, err)
+		return fmt.Errorf("failed opening destination file: %w", err)
 	}
 
 	defer func() {

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -44,7 +44,6 @@ func (Exec) Create(filename string, opts ...CreateOption) error {
 }
 
 func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error {
-	log = log.WithName("createEmptyFileWithSeek").WithValues("filename", filename)
 	dstFile, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
 	if err != nil {
 		return fmt.Errorf("failed opening destination file: %w", err)
@@ -53,7 +52,7 @@ func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error
 	defer func() {
 		destErr := dstFile.Close()
 		if destErr != nil {
-			log.Error(destErr, "error closing file")
+			log.WithName("createEmptyFileWithSeek").Error(destErr, "error closing file", "filename", filename)
 		}
 	}()
 
@@ -74,9 +73,8 @@ func copyFile(log logr.Logger, src, dst string) error {
 		return fmt.Errorf("failed opening source file: %w", err)
 	}
 	defer func() {
-		srcErr := srcFile.Close()
-		if srcErr != nil {
-			log.Error(srcErr, "error closing source file")
+		if err := srcFile.Close(); err != nil {
+			log.Error(err, "error closing source file")
 		}
 	}()
 
@@ -86,9 +84,8 @@ func copyFile(log logr.Logger, src, dst string) error {
 	}
 
 	defer func() {
-		destErr := dstFile.Close()
-		if destErr != nil {
-			log.Error(destErr, "error closing destination file")
+		if err := dstFile.Close(); err != nil {
+			log.Error(err, "error closing destination file")
 		}
 	}()
 

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -29,13 +29,11 @@ func (Exec) Create(filename string, opts ...CreateOption) error {
 		seek := *o.Size
 		// Position the file cursor one byte before the desired seek position to write a single byte,
 		// to ensure that data is written at the exact byte position specified by seek.
-		err := createEmptyFileWithSeek(log, filename, seek-1)
-		if err != nil {
+		if err := createEmptyFileWithSeek(log, filename, seek-1); err != nil {
 			return fmt.Errorf("failed creating the empty ephemeral disk at %s: %w", filename, err)
 		}
 	} else {
-		err := copyFile(log, o.SourceFile, filename)
-		if err != nil {
+		if err := copyFile(log, o.SourceFile, filename); err != nil {
 			return fmt.Errorf("failed creating virtual disk image, source: %s, destination: %s: %w", o.SourceFile, filename, err)
 		}
 	}
@@ -55,14 +53,15 @@ func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error
 		}
 	}()
 
-	_, err = dstFile.Seek(seek, io.SeekStart)
-	if err != nil {
+	if _, err = dstFile.Seek(seek, io.SeekStart); err != nil {
 		return fmt.Errorf("failed seeking destination file: %w", err)
 	}
 
-	_, err = dstFile.Write([]byte{0})
+	if _, err = dstFile.Write([]byte{0}); err != nil {
+		return fmt.Errorf("failed to write data to destination file: %w", err)
+	}
 
-	return err
+	return nil
 }
 
 func copyFile(log logr.Logger, src, dst string) error {
@@ -87,9 +86,11 @@ func copyFile(log logr.Logger, src, dst string) error {
 		}
 	}()
 
-	_, err = io.Copy(dstFile, srcFile)
+	if _, err = io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("failed to copy data from source file to destination file: %w", err)
+	}
 
-	return err
+	return nil
 }
 
 func init() {

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -15,12 +15,12 @@ import (
 
 type Exec struct{}
 
-const filePerm = 0644
+const filePerm = 0640
 
 func (Exec) Create(filename string, opts ...CreateOption) error {
 	o := &CreateOptions{}
 	o.ApplyOptions(opts)
-	log := ctrl.Log
+	log := ctrl.Log.WithName("raw-disk")
 
 	if o.SourceFile == "" {
 		if o.Size == nil {
@@ -63,11 +63,8 @@ func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error
 	}
 
 	_, err = dstFile.Write([]byte{0})
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func copyFile(log logr.Logger, src, dst string) error {

--- a/pkg/raw/raw_exec.go
+++ b/pkg/raw/raw_exec.go
@@ -20,7 +20,7 @@ const filePerm = 0660
 func (Exec) Create(filename string, opts ...CreateOption) error {
 	o := &CreateOptions{}
 	o.ApplyOptions(opts)
-	log := ctrl.Log.WithName("raw-disk")
+	log := ctrl.Log.WithName("raw-disk").WithValues("filename", filename)
 
 	if o.SourceFile == "" {
 		if o.Size == nil {
@@ -52,7 +52,7 @@ func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error
 	defer func() {
 		destErr := dstFile.Close()
 		if destErr != nil {
-			log.WithName("createEmptyFileWithSeek").Error(destErr, "error closing file", "filename", filename)
+			log.Error(destErr, "error closing file in createEmptyFileWithSeek")
 		}
 	}()
 
@@ -67,14 +67,13 @@ func createEmptyFileWithSeek(log logr.Logger, filename string, seek int64) error
 }
 
 func copyFile(log logr.Logger, src, dst string) error {
-	log = log.WithName("copyFile").WithValues("source", src, "destination", dst)
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("failed opening source file: %w", err)
 	}
 	defer func() {
 		if err := srcFile.Close(); err != nil {
-			log.Error(err, "error closing source file")
+			log.Error(err, "error closing source file in copyFile", "path", src)
 		}
 	}()
 
@@ -85,7 +84,7 @@ func copyFile(log logr.Logger, src, dst string) error {
 
 	defer func() {
 		if err := dstFile.Close(); err != nil {
-			log.Error(err, "error closing destination file")
+			log.Error(err, "error closing destination file in copyFile")
 		}
 	}()
 


### PR DESCRIPTION
# Proposed Changes

Replacing the two dd commands used in raw_exec.go with two functions:

- a function designed to create an empty file at a specific seek position within the file system
- a function designed to copy the contents of one file to another while also providing the ability to specify a seek position within the destination file where the data will be written

Fixes https://github.com/ironcore-dev/libvirt-provider/issues/214