### PR TITLE
Fixed `NIC` PCI address conflict

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - lukasfrank:fix/nic-pci-conflict
     tags:
       - v*
     paths-ignore:
@@ -57,7 +56,7 @@ jobs:
           version: latest
           endpoint: builders
       - name: Login to GHCR
-        if: true
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -70,8 +69,7 @@ jobs:
           context: .
           #TODO: Fix linux/arm64 build
           platforms: linux/amd64 #,linux/arm64
-          push: true
-#          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ matrix.image.target }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -70,6 +70,7 @@ jobs:
           context: .
           #TODO: Fix linux/arm64 build
           platforms: linux/amd64 #,linux/arm64
+          push: true
 #          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -57,7 +57,6 @@ jobs:
           version: latest
           endpoint: builders
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - lukasfrank:fix/nic-pci-conflict
     tags:
       - v*
     paths-ignore:
@@ -69,7 +70,7 @@ jobs:
           context: .
           #TODO: Fix linux/arm64 build
           platforms: linux/amd64 #,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+#          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ matrix.image.target }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -57,6 +57,7 @@ jobs:
           version: latest
           endpoint: builders
       - name: Login to GHCR
+        if: true
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/internal/controllers/machine_controller_nics.go
+++ b/internal/controllers/machine_controller_nics.go
@@ -427,7 +427,6 @@ func networkInterfaceAlias(name string) string {
 func providerNetworkInterfaceToLibvirt(name string, nic *providernetworkinterface.NetworkInterface) (*libvirtNetworkInterface, error) {
 	switch {
 	case nic.HostDevice != nil:
-		var zero uint
 		return &libvirtNetworkInterface{
 			hostDev: &libvirtxml.DomainHostdev{
 				Alias: &libvirtxml.DomainAlias{
@@ -442,14 +441,6 @@ func providerNetworkInterfaceToLibvirt(name string, nic *providernetworkinterfac
 							Slot:     &nic.HostDevice.Slot,
 							Function: &nic.HostDevice.Function,
 						},
-					},
-				},
-				Address: &libvirtxml.DomainAddress{
-					PCI: &libvirtxml.DomainAddressPCI{
-						Domain:   &nic.HostDevice.Domain,
-						Bus:      &nic.HostDevice.Bus,
-						Slot:     &zero,
-						Function: &zero,
 					},
 				},
 			},

--- a/internal/controllers/machine_controller_nics.go
+++ b/internal/controllers/machine_controller_nics.go
@@ -443,6 +443,10 @@ func providerNetworkInterfaceToLibvirt(name string, nic *providernetworkinterfac
 						},
 					},
 				},
+				Address: &libvirtxml.DomainAddress{
+					//if not defined, not conflicting pci address will be selected
+					PCI: &libvirtxml.DomainAddressPCI{},
+				},
 			},
 		}, nil
 	case nic.Isolated != nil:


### PR DESCRIPTION
# Proposed Changes

• Fix PCI address conflict, when two NICs are attached

Example:  
`Host Device 1: {"Domain":0,"Bus":6,"Slot":10,"Function":6} `
`Host Device 2: {"Domain":0,"Bus":6,"Slot":7,"Function":3}`
->
```
2024-06-03T09:09:32Z    ERROR    machine-reconciler    failed to reconcile machine    {"machineID": "2cce1b40-f6cb-4353-9cea-a1f81cf270c0", "error": "XML error: Attempted double use of PCI Address 0000:06:00.0"}```