### PR TITLE
Remove redundant nil check for Ignition in `setDomainIgnition` function

### DIFF
--- a/internal/controllers/machine_controller.go
+++ b/internal/controllers/machine_controller.go
@@ -893,9 +893,6 @@ func (r *MachineReconciler) setDomainImage(
 }
 
 func (r *MachineReconciler) setDomainIgnition(machine *api.Machine, domain *libvirtxml.Domain) error {
-	if machine.Spec.Ignition == nil {
-		return fmt.Errorf("no IgnitionData found in the Machine %s", machine.GetID())
-	}
 	ignitionData := machine.Spec.Ignition
 
 	ignPath := r.host.MachineIgnitionFile(machine.ID)


### PR DESCRIPTION
# Proposed Changes

The `setDomainIgnition` function is called only when `machine.Spec.Ignition` is not nil (see [reference](https://github.com/ironcore-dev/libvirt-provider/blob/04de659f9f6fbda773c4d2e5d5f121ee5ddfae6a/internal/controllers/machine_controller.go#L706)).

Therefore, it does not make sense to validate again inside the function if `Ignition` is nil (see [reference](https://github.com/ironcore-dev/libvirt-provider/blob/04de659f9f6fbda773c4d2e5d5f121ee5ddfae6a/internal/controllers/machine_controller.go#L896)). Hence, this redundant check can be removed.