### PR TITLE
Improved `gRPC` error codes for `IRI` methods

### DIFF
--- a/internal/server/common.go
+++ b/internal/server/common.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+package server
+
+import (
+	"errors"
+
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	ErrMachineNotFound            = errors.New("machine not found")
+	ErrNicNotFound                = errors.New("nic not found")
+	ErrVolumeNotFound             = errors.New("volume not found")
+	ErrMachineIsntManaged         = errors.New("machine isn't managed")
+	ErrMachineUnavailable         = errors.New("machine isn't available")
+	ErrPCIControllerMaxedOut      = errors.New("pci controllers count already maxed out")
+	ErrActiveConsoleSessionExists = errors.New("active console session exists for this domain")
+	ErrInvalidRequest             = errors.New("invalid request")
+)
+
+func convertInternalErrorToGRPC(err error) error {
+	_, ok := status.FromError(err)
+	if ok {
+		return err
+	}
+
+	code := codes.Internal
+
+	switch {
+	case errors.Is(err, store.ErrNotFound), errors.Is(err, ErrMachineNotFound), errors.Is(err, ErrVolumeNotFound), errors.Is(err, ErrNicNotFound):
+		code = codes.NotFound
+	case errors.Is(err, ErrMachineIsntManaged):
+		code = codes.InvalidArgument
+	case errors.Is(err, ErrPCIControllerMaxedOut):
+		code = codes.ResourceExhausted
+	case errors.Is(err, ErrActiveConsoleSessionExists):
+		code = codes.FailedPrecondition
+	case errors.Is(err, ErrMachineUnavailable):
+		code = codes.Unavailable
+	case errors.Is(err, ErrInvalidRequest):
+		code = codes.InvalidArgument
+	}
+
+	return status.Error(code, err.Error())
+}

--- a/internal/server/machine_create.go
+++ b/internal/server/machine_create.go
@@ -103,13 +103,13 @@ func (s *Server) CreateMachine(ctx context.Context, req *iri.CreateMachineReques
 	log.V(1).Info("Creating machine from iri machine")
 	machine, err := s.createMachineFromIRIMachine(ctx, log, req.Machine)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get libvirt machine config: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("unable to get libvirt machine config: %w", err))
 	}
 
 	log.V(1).Info("Converting machine to iri machine")
 	iriMachine, err := s.convertMachineToIRIMachine(ctx, log, machine)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert machine: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("unable to convert machine: %w", err))
 	}
 
 	return &iri.CreateMachineResponse{

--- a/internal/server/machine_delete.go
+++ b/internal/server/machine_delete.go
@@ -5,13 +5,9 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
-	"github.com/ironcore-dev/provider-utils/storeutils/store"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func (s *Server) DeleteMachine(ctx context.Context, req *iri.DeleteMachineRequest) (*iri.DeleteMachineResponse, error) {
@@ -19,10 +15,7 @@ func (s *Server) DeleteMachine(ctx context.Context, req *iri.DeleteMachineReques
 
 	log.V(1).Info("Deleting machine")
 	if err := s.machineStore.Delete(ctx, req.MachineId); err != nil {
-		if !errors.Is(err, store.ErrNotFound) {
-			return nil, fmt.Errorf("error deleting machine: %w", err)
-		}
-		return nil, status.Errorf(codes.NotFound, "machine %s not found", req.MachineId)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("error deleting machine: '%s': %w", req.MachineId, err))
 	}
 
 	return &iri.DeleteMachineResponse{}, nil

--- a/internal/server/machine_networkinterface_attach.go
+++ b/internal/server/machine_networkinterface_attach.go
@@ -15,17 +15,17 @@ func (s *Server) AttachNetworkInterface(ctx context.Context, req *iri.AttachNetw
 	log.V(1).Info("Attaching NIC to machine")
 
 	if req == nil {
-		return nil, fmt.Errorf("AttachNetworkInterfaceRequest is nil")
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("AttachNetworkInterfaceRequest is nil: %w", ErrInvalidRequest))
 	}
 
 	apiMachine, err := s.machineStore.Get(ctx, req.MachineId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get machine: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("failed to get machine '%s': %w", req.MachineId, err))
 	}
 
 	nicSpec, err := s.getNICFromIRINIC(req.NetworkInterface)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get nic from iri nic: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("failed to get nic from iri nic: %w", err))
 	}
 
 	apiMachine.Spec.NetworkInterfaces = append(apiMachine.Spec.NetworkInterfaces, nicSpec)

--- a/internal/server/machine_networkinterface_detach.go
+++ b/internal/server/machine_networkinterface_detach.go
@@ -19,12 +19,12 @@ func (s *Server) DetachNetworkInterface(
 	log.V(1).Info("Detaching nic from machine")
 
 	if req == nil {
-		return nil, fmt.Errorf("DetachNetworkInterface is nil")
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("DetachNetworkInterface is nil: %w", ErrInvalidRequest))
 	}
 
 	apiMachine, err := s.machineStore.Get(ctx, req.MachineId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get machine: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("failed to get machine '%s': %w", req.MachineId, err))
 	}
 
 	var updatedNICS []*api.NetworkInterfaceSpec
@@ -38,13 +38,13 @@ func (s *Server) DetachNetworkInterface(
 	}
 
 	if !found {
-		return nil, fmt.Errorf("nic '%s' not found in machine '%s'", req.Name, req.MachineId)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("nic '%s' not found in machine '%s': %w", req.Name, req.MachineId, ErrNicNotFound))
 	}
 
 	apiMachine.Spec.NetworkInterfaces = updatedNICS
 
 	if _, err := s.machineStore.Update(ctx, apiMachine); err != nil {
-		return nil, fmt.Errorf("failed to update machine: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("failed to update machine: %w", err))
 	}
 
 	return &iri.DetachNetworkInterfaceResponse{}, nil

--- a/internal/server/machine_volume_attach.go
+++ b/internal/server/machine_volume_attach.go
@@ -15,23 +15,23 @@ func (s *Server) AttachVolume(ctx context.Context, req *iri.AttachVolumeRequest)
 	log.V(1).Info("Attaching volume to machine")
 
 	if req == nil || req.MachineId == "" || req.Volume == nil {
-		return nil, fmt.Errorf("invalid request")
+		return nil, convertInternalErrorToGRPC(ErrInvalidRequest)
 	}
 
 	apiMachine, err := s.machineStore.Get(ctx, req.MachineId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get machine: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("failed to get machine '%s': %w", req.MachineId, err))
 	}
 
 	volumeSpec, err := s.getVolumeFromIRIVolume(req.Volume)
 	if err != nil {
-		return nil, fmt.Errorf("error converting volume: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("error converting volume: %w", err))
 	}
 
 	apiMachine.Spec.Volumes = append(apiMachine.Spec.Volumes, volumeSpec)
 
 	if _, err := s.machineStore.Update(ctx, apiMachine); err != nil {
-		return nil, fmt.Errorf("failed to update machine with new volume: %w", err)
+		return nil, convertInternalErrorToGRPC(fmt.Errorf("failed to update machine with new volume: %w", err))
 	}
 
 	return &iri.AttachVolumeResponse{}, nil


### PR DESCRIPTION
# Proposed Changes

- Return proper GRPC error codes for IRI methods
- Move `store.ErrNotFound` check to common place.

Fixes  #580 