### PR TITLE
Add server tests

### DIFF
--- a/internal/server/machine_annotations_update_test.go
+++ b/internal/server/machine_annotations_update_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	"github.com/ironcore-dev/libvirt-provider/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MachineAnnotationUpdate", func() {
+	It("should update machine annotation", func(ctx SpecContext) {
+		By("creating a machine")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foobar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+					Volumes: []*iri.Volume{
+						{
+							Name: "disk-1",
+							LocalDisk: &iri.LocalDisk{
+								SizeBytes: emptyDiskSize,
+							},
+							Device: "oda",
+						},
+					},
+					NetworkInterfaces: []*iri.NetworkInterface{
+						{
+							Name: "nic-1",
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("ensuring the machine gets created in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.MemoryBytes", int64(8589934592)),
+			HaveField("Spec.Cpu", int64(4)),
+			HaveField("Spec.Volumes", ContainElement(SatisfyAll(
+				HaveField("Name", "disk-1"),
+				HaveField("Device", "oda"),
+			))),
+			HaveField("Spec.NetworkInterfaces", ContainElement(SatisfyAll(
+				HaveField("Name", "nic-1"),
+			))),
+		))
+
+		By("updating machine annotations")
+		_, err = machineClient.UpdateMachineAnnotations(ctx, &iri.UpdateMachineAnnotationsRequest{
+			MachineId: createResp.Machine.Metadata.Id,
+			Annotations: map[string]string{
+				"machinepoolletv1alpha1.MachineUIDLabel": "fooUpdatedAnnotation",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("ensuring correct annotations updated in store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Metadata.Annotations", HaveKeyWithValue(
+				api.AnnotationsAnnotation, ContainSubstring("fooUpdatedAnnotation")),
+			)))
+	})
+})

--- a/internal/server/machine_annotations_update_test.go
+++ b/internal/server/machine_annotations_update_test.go
@@ -43,10 +43,7 @@ var _ = Describe("MachineAnnotationUpdate", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		By("ensuring the machine gets created in the store")
 		Eventually(func(g Gomega) *api.Machine {

--- a/internal/server/machine_create_test.go
+++ b/internal/server/machine_create_test.go
@@ -29,10 +29,7 @@ var _ = Describe("CreateMachine", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		By("ensuring the correct creation response")
 		Expect(createResp).Should(SatisfyAll(

--- a/internal/server/machine_delete_test.go
+++ b/internal/server/machine_delete_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	"github.com/ironcore-dev/libvirt-provider/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DeleteMachine", func() {
+	It("should delete a machine", func(ctx SpecContext) {
+		By("creating a machine")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foobar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+					Volumes: []*iri.Volume{
+						{
+							Name: "disk-1",
+							LocalDisk: &iri.LocalDisk{
+								SizeBytes: emptyDiskSize,
+							},
+							Device: "oda",
+						},
+					},
+					NetworkInterfaces: []*iri.NetworkInterface{
+						{
+							Name: "nic-1",
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+
+		By("ensuring the machine gets created in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.MemoryBytes", int64(8589934592)),
+			HaveField("Spec.Cpu", int64(4)),
+		))
+
+		deleteResp, err := machineClient.DeleteMachine(ctx, &iri.DeleteMachineRequest{
+			MachineId: createResp.Machine.Metadata.Id,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleteResp).NotTo(BeNil())
+
+		By("ensuring the machine gets deleted from the store")
+		Eventually(func(g Gomega) []*api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			return msList
+		}).Should(BeEmpty())
+	})
+})

--- a/internal/server/machine_list_test.go
+++ b/internal/server/machine_list_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ListMachine", func() {
+	It("should list machines", func(ctx SpecContext) {
+		By("creating machines")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foo",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		createMachineResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "bar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createMachineResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createMachineResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("ensuring the machines gets created in the store")
+		Eventually(func(g Gomega) {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(2))
+		}).Should(Succeed())
+
+		By("listing machines using machine Id")
+		listResp, err := machineClient.ListMachines(ctx, &iri.ListMachinesRequest{
+			Filter: &iri.MachineFilter{
+				Id: createResp.Machine.Metadata.Id,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listResp.Machines).NotTo(BeEmpty())
+		Expect(listResp.Machines).Should(HaveLen(1))
+
+		By("listing machines using correct Label selector")
+		listResp, err = machineClient.ListMachines(ctx, &iri.ListMachinesRequest{
+			Filter: &iri.MachineFilter{
+				LabelSelector: map[string]string{
+					"machinepoolletv1alpha1.MachineUIDLabel": "foo",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listResp.Machines).NotTo(BeEmpty())
+		Expect(listResp.Machines).Should(HaveLen(1))
+
+		By("listing machines using incorrect Label selector")
+		listResp, err = machineClient.ListMachines(ctx, &iri.ListMachinesRequest{
+			Filter: &iri.MachineFilter{
+				LabelSelector: map[string]string{
+					"foo": "wrong",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listResp).NotTo(BeNil())
+		Expect(listResp.Machines).To(BeEmpty())
+	})
+})

--- a/internal/server/machine_list_test.go
+++ b/internal/server/machine_list_test.go
@@ -28,10 +28,7 @@ var _ = Describe("ListMachine", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		createMachineResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
 			Machine: &iri.Machine{
@@ -48,10 +45,7 @@ var _ = Describe("ListMachine", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createMachineResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createMachineResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createMachineResp.Machine.Metadata.Id))
 
 		By("ensuring the machines gets created in the store")
 		Eventually(func(g Gomega) {

--- a/internal/server/machine_networkinterface_attach_test.go
+++ b/internal/server/machine_networkinterface_attach_test.go
@@ -29,10 +29,7 @@ var _ = Describe("NetworkInterfaceAttach", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		By("ensuring the correct creation response")
 		Expect(createResp).Should(SatisfyAll(

--- a/internal/server/machine_networkinterface_attach_test.go
+++ b/internal/server/machine_networkinterface_attach_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	"github.com/ironcore-dev/libvirt-provider/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NetworkInterfaceAttach", func() {
+	It("should attach a network interface to the machine", func(ctx SpecContext) {
+		By("creating a machine")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foobar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("ensuring the correct creation response")
+		Expect(createResp).Should(SatisfyAll(
+			HaveField("Machine.Metadata.Id", Not(BeEmpty())),
+			HaveField("Machine.Status.NetworkInterfaces", BeNil()),
+		))
+
+		By("ensuring the machine gets created in the store")
+		Eventually(func(g Gomega) {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+		}).Should(Succeed())
+
+		By("attaching network interface to the machine")
+		attachNetworkResp, err := machineClient.AttachNetworkInterface(ctx, &iri.AttachNetworkInterfaceRequest{
+			MachineId: createResp.Machine.Metadata.Id,
+			NetworkInterface: &iri.NetworkInterface{
+				Name: "nic-1",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(attachNetworkResp).NotTo(BeNil())
+
+		By("ensuring nic information is updated in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.NetworkInterfaces", ContainElement(SatisfyAll(
+				HaveField("Name", "nic-1"),
+			))),
+		))
+
+	})
+
+})

--- a/internal/server/machine_networkinterface_detach_test.go
+++ b/internal/server/machine_networkinterface_detach_test.go
@@ -37,10 +37,7 @@ var _ = Describe("NetworkInterfaceDetach", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		By("ensuring the correct creation response")
 		Expect(createResp).Should(SatisfyAll(

--- a/internal/server/machine_networkinterface_detach_test.go
+++ b/internal/server/machine_networkinterface_detach_test.go
@@ -76,7 +76,7 @@ var _ = Describe("NetworkInterfaceDetach", func() {
 			g.Expect(msList).To(HaveLen(1))
 			return msList[0]
 		}).Should(SatisfyAll(
-			HaveField("Spec.NetworkInterfaces", ContainElements(SatisfyAll(
+			HaveField("Spec.NetworkInterfaces", ConsistOf(SatisfyAll(
 				HaveField("Name", "nic-2"),
 			))),
 		))

--- a/internal/server/machine_networkinterface_detach_test.go
+++ b/internal/server/machine_networkinterface_detach_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	"github.com/ironcore-dev/libvirt-provider/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NetworkInterfaceDetach", func() {
+	It("should detach a network interface from the machine", func(ctx SpecContext) {
+		By("creating a machine with network interfaces")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foobar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+					NetworkInterfaces: []*iri.NetworkInterface{
+						{
+							Name: "nic-1",
+						},
+						{
+							Name: "nic-2",
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("ensuring the correct creation response")
+		Expect(createResp).Should(SatisfyAll(
+			HaveField("Machine.Metadata.Id", Not(BeEmpty())),
+			HaveField("Machine.Spec.NetworkInterfaces",
+				ConsistOf(
+					&iri.NetworkInterface{
+						Name: "nic-1"},
+					&iri.NetworkInterface{
+						Name: "nic-2",
+					},
+				)),
+		))
+
+		By("ensuring the machine gets created in the store")
+		Eventually(func(g Gomega) {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+		}).Should(Succeed())
+
+		By("detaching nic-1 network interface from the machine")
+		detachNetworkResp, err := machineClient.DetachNetworkInterface(ctx, &iri.DetachNetworkInterfaceRequest{
+			MachineId: createResp.Machine.Metadata.Id,
+			Name:      "nic-1",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detachNetworkResp).NotTo(BeNil())
+
+		By("ensuring nic information is updated in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.NetworkInterfaces", ContainElements(SatisfyAll(
+				HaveField("Name", "nic-2"),
+			))),
+		))
+	})
+})

--- a/internal/server/machine_powerstate_update_test.go
+++ b/internal/server/machine_powerstate_update_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	"github.com/ironcore-dev/libvirt-provider/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PowerStateUpdate", func() {
+	It("should update machine power state", func(ctx SpecContext) {
+		By("creating a machine")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foobar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("ensuring the correct creation response")
+		Expect(createResp).Should(SatisfyAll(
+			HaveField("Machine.Metadata.Id", Not(BeEmpty())),
+			HaveField("Machine.Spec.Power", iri.Power_POWER_ON),
+		))
+
+		By("ensuring the machine gets created in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.MemoryBytes", int64(8589934592)),
+			HaveField("Spec.Cpu", int64(4)),
+			HaveField("Spec.Power", api.PowerStatePowerOn),
+		))
+
+		By("updating power state of machine")
+		_, err = machineClient.UpdateMachinePower(ctx, &iri.UpdateMachinePowerRequest{
+			MachineId: createResp.Machine.Metadata.Id,
+			Power:     iri.Power_POWER_OFF,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("ensuring the correct power state updated in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.MemoryBytes", int64(8589934592)),
+			HaveField("Spec.Cpu", int64(4)),
+			HaveField("Spec.Power", api.PowerStatePowerOff),
+		))
+	})
+})

--- a/internal/server/machine_powerstate_update_test.go
+++ b/internal/server/machine_powerstate_update_test.go
@@ -29,10 +29,7 @@ var _ = Describe("PowerStateUpdate", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		By("ensuring the correct creation response")
 		Expect(createResp).Should(SatisfyAll(

--- a/internal/server/machine_volume_attach_test.go
+++ b/internal/server/machine_volume_attach_test.go
@@ -38,10 +38,7 @@ var _ = Describe("AttachVolume", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		By("ensuring the correct creation response")
 		Expect(createResp).Should(SatisfyAll(

--- a/internal/server/machine_volume_attach_test.go
+++ b/internal/server/machine_volume_attach_test.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	"github.com/ironcore-dev/libvirt-provider/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AttachVolume", func() {
+	It("should correctly attach volume to machine", func(ctx SpecContext) {
+		By("creating a machine")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foobar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+					Volumes: []*iri.Volume{
+						{
+							Name: "disk-1",
+							LocalDisk: &iri.LocalDisk{
+								SizeBytes: emptyDiskSize,
+							},
+							Device: "oda",
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("ensuring the correct creation response")
+		Expect(createResp).Should(SatisfyAll(
+			HaveField("Machine.Metadata.Id", Not(BeEmpty())),
+			HaveField("Machine.Spec.Volumes", ContainElement(&iri.Volume{
+				Name: "disk-1",
+				LocalDisk: &iri.LocalDisk{
+					SizeBytes: emptyDiskSize,
+				},
+				Device: "oda",
+			})),
+		))
+
+		By("ensuring the machine gets created in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.MemoryBytes", int64(8589934592)),
+			HaveField("Spec.Cpu", int64(4)),
+			HaveField("Spec.Volumes", ContainElement(SatisfyAll(
+				HaveField("Name", "disk-1"),
+				HaveField("Device", "oda"),
+			))),
+		))
+
+		By("attaching empty disk to a machine")
+		attachLocalDiskResp, err := machineClient.AttachVolume(ctx, &iri.AttachVolumeRequest{
+			MachineId: createResp.Machine.Metadata.Id,
+			Volume: &iri.Volume{
+				Name: "disk-2",
+				LocalDisk: &iri.LocalDisk{
+					SizeBytes: 5368709120,
+				},
+				Device: "odb",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(attachLocalDiskResp).NotTo(BeNil())
+
+		By("ensuring the volumes gets updated in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.MemoryBytes", int64(8589934592)),
+			HaveField("Spec.Cpu", int64(4)),
+			HaveField("Spec.Volumes", ContainElement(SatisfyAll(
+				HaveField("Name", "disk-2"),
+				HaveField("Device", "odb"),
+			))),
+		))
+
+	})
+})

--- a/internal/server/machine_volume_detach_test.go
+++ b/internal/server/machine_volume_detach_test.go
@@ -101,7 +101,7 @@ var _ = Describe("DetachVolume", func() {
 			g.Expect(msList).To(HaveLen(1))
 			return msList[0]
 		}).Should(
-			HaveField("Spec.Volumes", (ContainElements(SatisfyAll(
+			HaveField("Spec.Volumes", (ConsistOf(SatisfyAll(
 				HaveField("Name", "disk-2"),
 				HaveField("Device", "odb"),
 			))),

--- a/internal/server/machine_volume_detach_test.go
+++ b/internal/server/machine_volume_detach_test.go
@@ -45,10 +45,7 @@ var _ = Describe("DetachVolume", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createResp).NotTo(BeNil())
-		DeferCleanup(func() {
-			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		DeferCleanup(cleanupMachine(createResp.Machine.Metadata.Id))
 
 		By("ensuring the correct creation response")
 		Expect(createResp).Should(SatisfyAll(

--- a/internal/server/machine_volume_detach_test.go
+++ b/internal/server/machine_volume_detach_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
+	"github.com/ironcore-dev/libvirt-provider/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DetachVolume", func() {
+	It("should correctly detach volume from machine", func(ctx SpecContext) {
+		By("creating a machine")
+		createResp, err := machineClient.CreateMachine(ctx, &iri.CreateMachineRequest{
+			Machine: &iri.Machine{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						"machinepoolletv1alpha1.MachineUIDLabel": "foobar",
+					},
+				},
+				Spec: &iri.MachineSpec{
+					Power: iri.Power_POWER_ON,
+					Class: machineClassx3xlarge,
+					Volumes: []*iri.Volume{
+						{
+							Name: "disk-1",
+							LocalDisk: &iri.LocalDisk{
+								SizeBytes: emptyDiskSize,
+							},
+							Device: "oda",
+						},
+						{
+							Name: "disk-2",
+							LocalDisk: &iri.LocalDisk{
+								SizeBytes: emptyDiskSize,
+							},
+							Device: "odb",
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createResp).NotTo(BeNil())
+		DeferCleanup(func() {
+			err := machineStore.Delete(ctx, createResp.Machine.Metadata.Id)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		By("ensuring the correct creation response")
+		Expect(createResp).Should(SatisfyAll(
+			HaveField("Machine.Metadata.Id", Not(BeEmpty())),
+			HaveField("Machine.Spec.Volumes", ContainElements(&iri.Volume{
+				Name: "disk-1",
+				LocalDisk: &iri.LocalDisk{
+					SizeBytes: emptyDiskSize,
+				},
+				Device: "oda",
+			},
+				&iri.Volume{
+					Name: "disk-2",
+					LocalDisk: &iri.LocalDisk{
+						SizeBytes: emptyDiskSize,
+					},
+					Device: "odb",
+				})),
+		))
+
+		By("ensuring the machine gets created in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(SatisfyAll(
+			HaveField("Spec.MemoryBytes", int64(8589934592)),
+			HaveField("Spec.Cpu", int64(4)),
+			HaveField("Spec.Volumes", ContainElements(SatisfyAll(
+				HaveField("Name", "disk-1"),
+				HaveField("Device", "oda"),
+			), SatisfyAll(
+				HaveField("Name", "disk-2"),
+				HaveField("Device", "odb"),
+			))),
+		))
+
+		By("detaching volume from machine")
+		diskDetachResp, err := machineClient.DetachVolume(ctx, &iri.DetachVolumeRequest{
+			MachineId: createResp.Machine.Metadata.Id,
+			Name:      "disk-1",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(diskDetachResp).NotTo(BeNil())
+
+		By("ensuring the volumes gets removed in the store")
+		Eventually(func(g Gomega) *api.Machine {
+			msList, err := machineStore.List(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(msList).NotTo(BeEmpty())
+			g.Expect(msList).To(HaveLen(1))
+			return msList[0]
+		}).Should(
+			HaveField("Spec.Volumes", (ContainElements(SatisfyAll(
+				HaveField("Name", "disk-2"),
+				HaveField("Device", "odb"),
+			))),
+			))
+	})
+})


### PR DESCRIPTION
# Proposed Changes

- Added server tests to validate the corresponding store objects have been updated according to IRI methods.

Contributes to https://github.com/ironcore-dev/libvirt-provider/issues/541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites covering machine lifecycle: creation, deletion, listing, annotation updates, and power-state transitions.
  * Added integration-style tests for attaching/detaching network interfaces and volumes, verifying store state before and after operations.
  * Strengthened cleanup and teardown by standardizing teardown helpers and DeferCleanup usage.
  * Enhanced label-based selection and filtering validation for machine discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->