### PR TITLE
Pin go toolchain version to 1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # Build the libvirt-provider binary
-FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1-bookworm AS builder
+
+# Prevent Go from downloading a different toolchain at build time.
+# The Docker image IS the toolchain — if go.mod requires something newer,
+# we want a loud failure, not a silent download.
+ENV GOTOOLCHAIN=local
 
 WORKDIR /workspace
 
@@ -50,7 +55,7 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
         mv /go/bin/linux_$TARGETARCH/irictl-machine /workspace/irictl-machine; \
     fi
 
-    
+
 FROM busybox:1.37.0-uclibc AS busybox
 
 # Since we're leveraging apt to pull in dependencies, we use `gcr.io/distroless/base` because it includes glibc.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ironcore-dev/libvirt-provider
 
 go 1.24.1
 
+toolchain go1.26.1
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/digitalocean/go-libvirt v0.0.0-20250616175656-5843751af96c


### PR DESCRIPTION
This defines the go version this project is being build with. To avoid confusion with the build of the Dockerfile, the `ENV GOTOOLCHAIN=local` variable ensures that the Dockerfile cannot be build if the bundled go version is older, without secretly downloading the newer version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.26.1.
  * Optimized Docker image with distroless base for reduced size and improved security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->