### PR TITLE
Extend `apinet-nic-plugin` to watch and cleanup NICs

### DIFF
--- a/cmd/libvirt-provider/app/app.go
+++ b/cmd/libvirt-provider/app/app.go
@@ -286,8 +286,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	setupLog.Info("Initializing network interface plugin")
-
-	if err := nicPlugin.Init(providerHost); err != nil {
+	if err := nicPlugin.Init(ctx, providerHost); err != nil {
 		setupLog.Error(err, "failed to initialize network plugin")
 		return err
 	}

--- a/internal/controllers/controllers_suite_test.go
+++ b/internal/controllers/controllers_suite_test.go
@@ -184,7 +184,7 @@ var _ = BeforeSuite(func() {
 	if cleanup != nil {
 		DeferCleanup(cleanup)
 	}
-	Expect(networkPlugin.Init(providerHost)).To(Succeed())
+	Expect(networkPlugin.Init(pluginCtx, providerHost)).To(Succeed())
 
 	By("setting up resource claimer")
 	resClaimer, err = claim.NewResourceClaimer(

--- a/internal/controllers/machine_controller.go
+++ b/internal/controllers/machine_controller.go
@@ -173,6 +173,13 @@ func (r *MachineReconciler) Start(ctx context.Context) error {
 		},
 	})
 
+	r.networkInterfacePlugin.AddEventHandler(providernetworkinterface.EventHandlerFuncs{
+		HandleNICEventFunc: func(machineID string) {
+			log.V(1).Info("NIC event: Requeue machine", "Machine", machineID)
+			r.queue.Add(machineID)
+		},
+	})
+
 	imgEventReg, err := r.machineEvents.AddHandler(event.HandlerFunc[*api.Machine](func(evt event.Event[*api.Machine]) {
 		r.queue.Add(evt.Object.ID)
 	}))

--- a/internal/controllers/machine_controller_nics.go
+++ b/internal/controllers/machine_controller_nics.go
@@ -164,19 +164,26 @@ func (r *MachineReconciler) attachDetachNetworkInterfaces(
 		mountedNic, err := r.reconcileDesiredNetworkInterface(ctx, machine, domain, mountedNics, desiredNic)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("[network interface %s] error reconciling: %w", nicName, err))
-		} else {
-			log.V(1).Info("Successfully reconciled desired network interface", "NetworkInterfaceName", nicName)
-			mountedNics[nicName] = *mountedNic
-			nicStates = append(nicStates, api.NetworkInterfaceStatus{
-				Name:   nicName,
-				Handle: mountedNic.networkInterface.Handle,
-				State:  api.NetworkInterfaceStateAttached,
-			})
+			continue
 		}
+		if mountedNic == nil {
+			continue
+		}
+		log.V(1).Info("Successfully reconciled desired network interface", "NetworkInterfaceName", nicName)
+		mountedNics[nicName] = *mountedNic
+		nicStates = append(nicStates, api.NetworkInterfaceStatus{
+			Name:   nicName,
+			Handle: mountedNic.networkInterface.Handle,
+			State:  api.NetworkInterfaceStateAttached,
+		})
 	}
 
 	for nicName, machineNic := range machineNicByName {
 		if _, ok := mountedNics[nicName]; ok {
+			continue
+		}
+		if _, ok := desiredNics[nicName]; ok {
+			log.V(1).Info("Skipping not ready NICs", "NetworkInterfaceName", nicName)
 			continue
 		}
 
@@ -210,6 +217,9 @@ func (r *MachineReconciler) reconcileDesiredNetworkInterface(
 	nic *api.NetworkInterfaceSpec,
 ) (*mountedNetworkInterface, error) {
 	providerNic, err := r.networkInterfacePlugin.Apply(ctx, nic, machine)
+	if errors.Is(err, providernetworkinterface.ErrNotReady) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controllers/machine_controller_nics.go
+++ b/internal/controllers/machine_controller_nics.go
@@ -217,9 +217,6 @@ func (r *MachineReconciler) reconcileDesiredNetworkInterface(
 	nic *api.NetworkInterfaceSpec,
 ) (*mountedNetworkInterface, error) {
 	providerNic, err := r.networkInterfacePlugin.Apply(ctx, nic, machine)
-	if errors.Is(err, providernetworkinterface.ErrNotReady) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/networkinterfaceplugin/apinet.go
+++ b/internal/networkinterfaceplugin/apinet.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"time"
 
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
@@ -21,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var scheme = runtime.NewScheme()
@@ -32,9 +30,7 @@ func init() {
 }
 
 type apinetOptions struct {
-	APInetNodeName  string
-	PollingDuration time.Duration
-	PollingInterval time.Duration
+	APInetNodeName string
 
 	GetConfigOptions config.GetConfigOptions
 }
@@ -45,8 +41,6 @@ func (o *apinetOptions) PluginName() string {
 
 func (o *apinetOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.APInetNodeName, "apinet-node-name", "", "APInet node name")
-	fs.DurationVar(&o.PollingDuration, "apinet-polling-duration", 30*time.Second, "Duration to poll for apinet network interface readiness")
-	fs.DurationVar(&o.PollingInterval, "apinet-polling-interval", 1*time.Second, "Interval between apinet network interface readiness polls")
 	o.GetConfigOptions.BindFlags(fs, config.WithNamePrefix("apinet-"))
 }
 
@@ -80,12 +74,7 @@ func (o *apinetOptions) NetworkInterfacePlugin(ctx context.Context) (
 		return nil, nil, nil, fmt.Errorf("error getting apinet config: %w", err)
 	}
 
-	apinetClient, err := client.New(cfg, client.Options{Scheme: scheme})
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error creating apinet client: %w", err)
-	}
-
-	return apinet.NewPlugin(o.APInetNodeName, apinetClient, o.PollingDuration, o.PollingInterval), configCtrl, nil, nil
+	return apinet.NewPlugin(o.APInetNodeName, cfg), configCtrl, nil, nil
 }
 
 func init() {

--- a/internal/plugins/networkinterface/apinet/apinet.go
+++ b/internal/plugins/networkinterface/apinet/apinet.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 
 	apinetv1alpha1 "github.com/ironcore-dev/ironcore-net/api/core/v1alpha1"
@@ -26,8 +26,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,22 +44,29 @@ const (
 	perm         = 0o777
 	filePerm     = 0o666
 	pluginAPInet = "apinet"
+
+	labelMachineID = "libvirt-provider.ironcore.dev/machine-id"
 )
 
-type Plugin struct {
-	nodeName        string
-	host            providerhost.LibvirtHost
-	apinetClient    client.Client
-	pollingInterval time.Duration
-	pollingDuration time.Duration
+var watcherScheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(watcherScheme))
+	utilruntime.Must(apinetv1alpha1.AddToScheme(watcherScheme))
 }
 
-func NewPlugin(nodeName string, client client.Client, duration, interval time.Duration) providernetworkinterface.Plugin {
+type Plugin struct {
+	nodeName      string
+	host          providerhost.LibvirtHost
+	apinetClient  client.Client
+	restConfig    *rest.Config
+	eventHandlers []providernetworkinterface.EventHandler
+}
+
+func NewPlugin(nodeName string, restCfg *rest.Config) providernetworkinterface.Plugin {
 	return &Plugin{
-		nodeName:        nodeName,
-		apinetClient:    client,
-		pollingDuration: duration,
-		pollingInterval: interval,
+		nodeName:   nodeName,
+		restConfig: restCfg,
 	}
 }
 
@@ -62,9 +74,36 @@ func GetAPInetPlugin() *Plugin {
 	return &Plugin{}
 }
 
-func (p *Plugin) Init(host providerhost.LibvirtHost) error {
+func (p *Plugin) Init(ctx context.Context, host providerhost.LibvirtHost) error {
 	p.host = host
+
+	apinetClient, err := client.New(p.restConfig, client.Options{Scheme: watcherScheme})
+	if err != nil {
+		return fmt.Errorf("error creating apinet client: %w", err)
+	}
+	p.apinetClient = apinetClient
+
+	go p.runWatcher(ctx)
 	return nil
+}
+
+func (p *Plugin) AddEventHandler(handler providernetworkinterface.EventHandler) {
+	p.eventHandlers = append(p.eventHandlers, handler)
+}
+
+func (p *Plugin) RemoveEventHandler(handler providernetworkinterface.EventHandler) {
+	for i, h := range p.eventHandlers {
+		if h == handler {
+			p.eventHandlers = append(p.eventHandlers[:i], p.eventHandlers[i+1:]...)
+			return
+		}
+	}
+}
+
+func (p *Plugin) notifyEventHandlers(machineID string) {
+	for _, h := range p.eventHandlers {
+		h.HandleNICEvent(machineID)
+	}
 }
 
 func ironcoreIPsToAPInetIPs(ips []string) []apinet.IP {
@@ -137,6 +176,9 @@ func (p *Plugin) Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, mach
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: apinetNamespace,
 			Name:      p.APInetNicName(machine.ID, spec.Name),
+			Labels: map[string]string{
+				labelMachineID: machine.ID,
+			},
 		},
 		Spec: apinetv1alpha1.NetworkInterfaceSpec{
 			NetworkRef: corev1.LocalObjectReference{
@@ -158,51 +200,10 @@ func (p *Plugin) Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, mach
 	if err != nil {
 		return nil, fmt.Errorf("error getting host device: %w", err)
 	}
-	if hostDev != nil {
-		log.V(1).Info("Host device is ready", "HostDevice", hostDev)
-		return &providernetworkinterface.NetworkInterface{
-			Handle: provider.GetNetworkInterfaceID(
-				apinetNic.Namespace,
-				apinetNic.Name,
-				apinetNic.Spec.NodeRef.Name,
-				apinetNic.UID,
-			),
-			HostDevice: hostDev,
-		}, nil
-	}
 
-	if direct != nil {
-		log.V(1).Info("Direct device is ready", "Direct", direct)
-		return &providernetworkinterface.NetworkInterface{
-			Handle: provider.GetNetworkInterfaceID(
-				apinetNic.Namespace,
-				apinetNic.Name,
-				apinetNic.Spec.NodeRef.Name,
-				apinetNic.UID,
-			),
-			Direct: direct,
-		}, nil
-	}
-
-	log.V(1).Info("Waiting for apinet network interface to become ready")
-	apinetNicKey := client.ObjectKeyFromObject(apinetNic)
-	if err := wait.PollUntilContextTimeout(ctx, p.pollingInterval, p.pollingDuration, true, func(ctx context.Context) (done bool, err error) {
-		if err := p.apinetClient.Get(ctx, apinetNicKey, apinetNic); err != nil {
-			return false, fmt.Errorf("error getting apinet nic %s: %w", apinetNicKey, err)
-		}
-
-		hostDev, direct, err = getHostDevice(apinetNic)
-		if err != nil {
-			return false, fmt.Errorf("error getting host device: %w", err)
-		}
-		return hostDev != nil || direct != nil, nil
-	}); err != nil {
-		return nil, fmt.Errorf("error waiting for nic to become ready: %w", err)
-	}
-
-	// Fetch the updated object to get the ID or any other updated fields
-	if err := p.apinetClient.Get(ctx, apinetNicKey, apinetNic); err != nil {
-		return nil, fmt.Errorf("error fetching updated apinet network interface: %w", err)
+	if hostDev == nil && direct == nil {
+		log.V(1).Info("APINet NIC not ready yet, will be requeued by watcher")
+		return nil, providernetworkinterface.ErrNotReady
 	}
 
 	return &providernetworkinterface.NetworkInterface{
@@ -283,43 +284,154 @@ func (p *Plugin) Delete(ctx context.Context, computeNicName, machineID string) e
 		return os.RemoveAll(p.host.MachineNetworkInterfaceDir(machineID, computeNicName))
 	}
 
-	apinetNicKey := client.ObjectKey{
-		Namespace: cfg.Namespace,
-		Name:      p.APInetNicName(machineID, computeNicName),
-	}
-	log = log.WithValues("APInetNetworkInterfaceKey", apinetNicKey)
-
-	if err := p.apinetClient.Delete(ctx, &apinetv1alpha1.NetworkInterface{
+	apinetNic := &apinetv1alpha1.NetworkInterface{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: apinetNicKey.Namespace,
-			Name:      apinetNicKey.Name,
+			Namespace: cfg.Namespace,
+			Name:      p.APInetNicName(machineID, computeNicName),
 		},
-	}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("error deleting apinet network interface %s: %w", apinetNicKey, err)
-		}
+	}
+	log = log.WithValues("APInetNetworkInterface", client.ObjectKeyFromObject(apinetNic))
 
-		log.V(1).Info("APInet network interface is already gone, removing network interface directory")
-		return os.RemoveAll(p.host.MachineNetworkInterfaceDir(machineID, computeNicName))
+	if err := p.apinetClient.Delete(ctx, apinetNic); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error deleting apinet network interface: %w", err)
 	}
 
-	log.V(1).Info("Waiting until apinet network interface is gone")
-	if err := wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		if err := p.apinetClient.Get(ctx, apinetNicKey, &apinetv1alpha1.NetworkInterface{}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return false, fmt.Errorf("error getting apinet network interface %s: %w", apinetNicKey, err)
-			}
-			return true, nil
-		}
-		return false, nil
-	}); err != nil {
-		return fmt.Errorf("error waiting for apinet network interface %s to be gone: %w", apinetNicKey, err)
-	}
-
-	log.V(1).Info("APInet network interface is gone, removing network interface dir")
+	log.V(1).Info("APInet network interface delete requested, removing network interface dir")
 	return os.RemoveAll(p.host.MachineNetworkInterfaceDir(machineID, computeNicName))
 }
 
 func (p *Plugin) Name() string {
 	return pluginAPInet
+}
+
+func (p *Plugin) runWatcher(ctx context.Context) {
+	log := ctrl.Log.WithName("apinet-watcher")
+
+	c, err := cache.New(p.restConfig, cache.Options{
+		Scheme: watcherScheme,
+		ByObject: map[client.Object]cache.ByObject{
+			&apinetv1alpha1.NetworkInterface{}: {},
+		},
+	})
+	if err != nil {
+		log.Error(err, "Failed to create informer cache")
+		return
+	}
+
+	informer, err := c.GetInformer(ctx, &apinetv1alpha1.NetworkInterface{})
+	if err != nil {
+		log.Error(err, "Failed to get informer")
+		return
+	}
+
+	if _, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			p.handleNICUpdate(log, oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			p.handleNICDelete(log, obj)
+		},
+	}); err != nil {
+		log.Error(err, "Failed to add event handler")
+		return
+	}
+
+	go func() {
+		if err := c.Start(ctx); err != nil {
+			log.Error(err, "Informer cache stopped with error")
+		}
+	}()
+
+	if !c.WaitForCacheSync(ctx) {
+		log.Error(fmt.Errorf("cache sync failed"), "Failed to sync informer cache")
+		return
+	}
+	log.Info("Informer cache synced, enqueuing machines for NIC reconciliation")
+
+	p.enqueueNICMachines(ctx, log, c)
+
+	<-ctx.Done()
+}
+
+func (p *Plugin) handleNICUpdate(log logr.Logger, oldObj, newObj interface{}) {
+	newNic, ok := newObj.(*apinetv1alpha1.NetworkInterface)
+	if !ok {
+		return
+	}
+
+	if newNic.Spec.NodeRef.Name != p.nodeName {
+		return
+	}
+
+	oldNic, ok := oldObj.(*apinetv1alpha1.NetworkInterface)
+	if !ok {
+		return
+	}
+
+	if oldNic.Status.State == newNic.Status.State {
+		return
+	}
+
+	machineID := newNic.Labels[labelMachineID]
+	if machineID == "" {
+		return
+	}
+
+	log.V(1).Info("NIC state changed, requeueing machine", "machineID", machineID, "nic", newNic.Name, "oldState", oldNic.Status.State, "newState", newNic.Status.State)
+	p.notifyEventHandlers(machineID)
+}
+
+func (p *Plugin) handleNICDelete(log logr.Logger, obj interface{}) {
+	nic, ok := obj.(*apinetv1alpha1.NetworkInterface)
+	if !ok {
+		return
+	}
+
+	if nic.Spec.NodeRef.Name != p.nodeName {
+		return
+	}
+
+	machineID := nic.Labels[labelMachineID]
+	if machineID == "" {
+		log.V(2).Info("Ignoring NIC delete without machine-id label", "name", nic.Name, "namespace", nic.Namespace)
+		return
+	}
+
+	log.V(1).Info("NIC deleted, requeueing machine", "machineID", machineID, "nic", nic.Name)
+	p.notifyEventHandlers(machineID)
+}
+
+func (p *Plugin) enqueueNICMachines(ctx context.Context, log logr.Logger, c cache.Cache) {
+	nicList := &apinetv1alpha1.NetworkInterfaceList{}
+	if err := c.List(ctx, nicList); err != nil {
+		log.Error(err, "Failed to list NICs")
+		return
+	}
+
+	for i := range nicList.Items {
+		nic := &nicList.Items[i]
+		if nic.Spec.NodeRef.Name != p.nodeName {
+			continue
+		}
+
+		machineID := nic.Labels[labelMachineID]
+		if machineID == "" {
+			continue
+		}
+
+		if _, err := os.Stat(p.host.MachineDir(machineID)); err != nil {
+			if !os.IsNotExist(err) {
+				log.Error(err, "Failed to stat machine directory", "machineID", machineID)
+				continue
+			}
+			log.V(1).Info("Deleting stale APINet NIC", "machineID", machineID, "nic", nic.Name, "namespace", nic.Namespace)
+			if err := p.apinetClient.Delete(ctx, nic); err != nil && !apierrors.IsNotFound(err) {
+				log.Error(err, "Failed to delete stale NIC", "nic", nic.Name, "namespace", nic.Namespace)
+			}
+			continue
+		}
+
+		log.V(1).Info("Enqueuing machine", "machineID", machineID, "nic", nic.Name)
+		p.notifyEventHandlers(machineID)
+	}
 }

--- a/internal/plugins/networkinterface/apinet/apinet.go
+++ b/internal/plugins/networkinterface/apinet/apinet.go
@@ -97,17 +97,6 @@ func (p *Plugin) AddEventHandler(handler providernetworkinterface.EventHandler) 
 	p.eventHandlers = append(p.eventHandlers, handler)
 }
 
-func (p *Plugin) RemoveEventHandler(handler providernetworkinterface.EventHandler) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	for i, h := range p.eventHandlers {
-		if h == handler {
-			p.eventHandlers = append(p.eventHandlers[:i], p.eventHandlers[i+1:]...)
-			return
-		}
-	}
-}
-
 func (p *Plugin) notifyEventHandlers(machineID string) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/internal/plugins/networkinterface/apinet/apinet.go
+++ b/internal/plugins/networkinterface/apinet/apinet.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -60,6 +61,7 @@ type Plugin struct {
 	host          providerhost.LibvirtHost
 	apinetClient  client.Client
 	restConfig    *rest.Config
+	mu            sync.RWMutex
 	eventHandlers []providernetworkinterface.EventHandler
 }
 
@@ -88,10 +90,14 @@ func (p *Plugin) Init(ctx context.Context, host providerhost.LibvirtHost) error 
 }
 
 func (p *Plugin) AddEventHandler(handler providernetworkinterface.EventHandler) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.eventHandlers = append(p.eventHandlers, handler)
 }
 
 func (p *Plugin) RemoveEventHandler(handler providernetworkinterface.EventHandler) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	for i, h := range p.eventHandlers {
 		if h == handler {
 			p.eventHandlers = append(p.eventHandlers[:i], p.eventHandlers[i+1:]...)
@@ -101,6 +107,8 @@ func (p *Plugin) RemoveEventHandler(handler providernetworkinterface.EventHandle
 }
 
 func (p *Plugin) notifyEventHandlers(machineID string) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	for _, h := range p.eventHandlers {
 		h.HandleNICEvent(machineID)
 	}

--- a/internal/plugins/networkinterface/apinet/apinet.go
+++ b/internal/plugins/networkinterface/apinet/apinet.go
@@ -85,7 +85,9 @@ func (p *Plugin) Init(ctx context.Context, host providerhost.LibvirtHost) error 
 	}
 	p.apinetClient = apinetClient
 
-	go p.runWatcher(ctx)
+	if err := p.startWatcher(ctx); err != nil {
+		return fmt.Errorf("error starting NIC watcher: %w", err)
+	}
 	return nil
 }
 
@@ -312,7 +314,7 @@ func (p *Plugin) Name() string {
 	return pluginAPInet
 }
 
-func (p *Plugin) runWatcher(ctx context.Context) {
+func (p *Plugin) startWatcher(ctx context.Context) error {
 	log := ctrl.Log.WithName("apinet-watcher")
 
 	c, err := cache.New(p.restConfig, cache.Options{
@@ -322,14 +324,12 @@ func (p *Plugin) runWatcher(ctx context.Context) {
 		},
 	})
 	if err != nil {
-		log.Error(err, "Failed to create informer cache")
-		return
+		return fmt.Errorf("failed to create informer cache: %w", err)
 	}
 
 	informer, err := c.GetInformer(ctx, &apinetv1alpha1.NetworkInterface{})
 	if err != nil {
-		log.Error(err, "Failed to get informer")
-		return
+		return fmt.Errorf("failed to get informer: %w", err)
 	}
 
 	if _, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
@@ -340,8 +340,7 @@ func (p *Plugin) runWatcher(ctx context.Context) {
 			p.handleNICDelete(log, obj)
 		},
 	}); err != nil {
-		log.Error(err, "Failed to add event handler")
-		return
+		return fmt.Errorf("failed to add event handler: %w", err)
 	}
 
 	go func() {
@@ -351,14 +350,15 @@ func (p *Plugin) runWatcher(ctx context.Context) {
 	}()
 
 	if !c.WaitForCacheSync(ctx) {
-		log.Error(fmt.Errorf("cache sync failed"), "Failed to sync informer cache")
-		return
+		return fmt.Errorf("failed to sync informer cache")
 	}
 	log.Info("Informer cache synced, enqueuing machines for NIC reconciliation")
 
-	p.enqueueNICMachines(ctx, log, c)
+	if err := p.enqueueNICMachines(ctx, log, c); err != nil {
+		return err
+	}
 
-	<-ctx.Done()
+	return nil
 }
 
 func (p *Plugin) handleNICUpdate(log logr.Logger, oldObj, newObj interface{}) {
@@ -413,11 +413,10 @@ func (p *Plugin) handleNICDelete(log logr.Logger, obj interface{}) {
 	p.notifyEventHandlers(machineID)
 }
 
-func (p *Plugin) enqueueNICMachines(ctx context.Context, log logr.Logger, c cache.Cache) {
+func (p *Plugin) enqueueNICMachines(ctx context.Context, log logr.Logger, c cache.Cache) error {
 	nicList := &apinetv1alpha1.NetworkInterfaceList{}
 	if err := c.List(ctx, nicList); err != nil {
-		log.Error(err, "Failed to list NICs")
-		return
+		return fmt.Errorf("failed to list NICs: %w", err)
 	}
 
 	for i := range nicList.Items {
@@ -446,4 +445,6 @@ func (p *Plugin) enqueueNICMachines(ctx context.Context, log logr.Logger, c cach
 		log.V(1).Info("Enqueuing machine", "machineID", machineID, "nic", nic.Name)
 		p.notifyEventHandlers(machineID)
 	}
+
+	return nil
 }

--- a/internal/plugins/networkinterface/apinet/apinet.go
+++ b/internal/plugins/networkinterface/apinet/apinet.go
@@ -382,6 +382,10 @@ func (p *Plugin) handleNICUpdate(log logr.Logger, oldObj, newObj interface{}) {
 }
 
 func (p *Plugin) handleNICDelete(log logr.Logger, obj interface{}) {
+	if d, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+
 	nic, ok := obj.(*apinetv1alpha1.NetworkInterface)
 	if !ok {
 		return

--- a/internal/plugins/networkinterface/isolated/isolated.go
+++ b/internal/plugins/networkinterface/isolated/isolated.go
@@ -32,8 +32,6 @@ func (p *plugin) Init(ctx context.Context, host providerhost.LibvirtHost) error 
 
 func (p *plugin) AddEventHandler(handler providernetworkinterface.EventHandler) {}
 
-func (p *plugin) RemoveEventHandler(handler providernetworkinterface.EventHandler) {}
-
 func (p *plugin) Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, machine *api.Machine) (*providernetworkinterface.NetworkInterface, error) {
 	if err := os.MkdirAll(p.host.MachineNetworkInterfaceDir(machine.ID, spec.Name), perm); err != nil {
 		return nil, err

--- a/internal/plugins/networkinterface/isolated/isolated.go
+++ b/internal/plugins/networkinterface/isolated/isolated.go
@@ -25,10 +25,14 @@ func NewPlugin() providernetworkinterface.Plugin {
 	return &plugin{}
 }
 
-func (p *plugin) Init(host providerhost.LibvirtHost) error {
+func (p *plugin) Init(ctx context.Context, host providerhost.LibvirtHost) error {
 	p.host = host
 	return nil
 }
+
+func (p *plugin) AddEventHandler(handler providernetworkinterface.EventHandler) {}
+
+func (p *plugin) RemoveEventHandler(handler providernetworkinterface.EventHandler) {}
 
 func (p *plugin) Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, machine *api.Machine) (*providernetworkinterface.NetworkInterface, error) {
 	if err := os.MkdirAll(p.host.MachineNetworkInterfaceDir(machine.ID, spec.Name), perm); err != nil {

--- a/internal/plugins/networkinterface/plugins.go
+++ b/internal/plugins/networkinterface/plugins.go
@@ -31,7 +31,6 @@ type Plugin interface {
 	Name() string
 	Init(ctx context.Context, host providerhost.LibvirtHost) error
 	AddEventHandler(handler EventHandler)
-	RemoveEventHandler(handler EventHandler)
 
 	Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, machine *api.Machine) (*NetworkInterface, error)
 	Delete(ctx context.Context, computeNicName string, machineID string) error

--- a/internal/plugins/networkinterface/plugins.go
+++ b/internal/plugins/networkinterface/plugins.go
@@ -5,14 +5,33 @@ package networkinterface
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ironcore-dev/libvirt-provider/api"
 	providerhost "github.com/ironcore-dev/libvirt-provider/internal/host"
 )
 
+var ErrNotReady = errors.New("network interface not ready")
+
+type EventHandler interface {
+	HandleNICEvent(machineID string)
+}
+
+type EventHandlerFuncs struct {
+	HandleNICEventFunc func(machineID string)
+}
+
+func (l EventHandlerFuncs) HandleNICEvent(machineID string) {
+	if l.HandleNICEventFunc != nil {
+		l.HandleNICEventFunc(machineID)
+	}
+}
+
 type Plugin interface {
 	Name() string
-	Init(host providerhost.LibvirtHost) error
+	Init(ctx context.Context, host providerhost.LibvirtHost) error
+	AddEventHandler(handler EventHandler)
+	RemoveEventHandler(handler EventHandler)
 
 	Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, machine *api.Machine) (*NetworkInterface, error)
 	Delete(ctx context.Context, computeNicName string, machineID string) error

--- a/internal/plugins/networkinterface/providernetwork/providernetwork.go
+++ b/internal/plugins/networkinterface/providernetwork/providernetwork.go
@@ -32,8 +32,6 @@ func (p *plugin) Init(ctx context.Context, host providerhost.LibvirtHost) error 
 
 func (p *plugin) AddEventHandler(handler providernetworkinterface.EventHandler) {}
 
-func (p *plugin) RemoveEventHandler(handler providernetworkinterface.EventHandler) {}
-
 func (p *plugin) Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, machine *api.Machine) (*providernetworkinterface.NetworkInterface, error) {
 	if err := os.MkdirAll(p.host.MachineNetworkInterfaceDir(machine.ID, spec.Name), perm); err != nil {
 		return nil, err

--- a/internal/plugins/networkinterface/providernetwork/providernetwork.go
+++ b/internal/plugins/networkinterface/providernetwork/providernetwork.go
@@ -25,10 +25,14 @@ func NewPlugin() providernetworkinterface.Plugin {
 	return &plugin{}
 }
 
-func (p *plugin) Init(host providerhost.LibvirtHost) error {
+func (p *plugin) Init(ctx context.Context, host providerhost.LibvirtHost) error {
 	p.host = host
 	return nil
 }
+
+func (p *plugin) AddEventHandler(handler providernetworkinterface.EventHandler) {}
+
+func (p *plugin) RemoveEventHandler(handler providernetworkinterface.EventHandler) {}
 
 func (p *plugin) Apply(ctx context.Context, spec *api.NetworkInterfaceSpec, machine *api.Machine) (*providernetworkinterface.NetworkInterface, error) {
 	if err := os.MkdirAll(p.host.MachineNetworkInterfaceDir(machine.ID, spec.Name), perm); err != nil {


### PR DESCRIPTION
# Proposed Changes

- Extend `apinet-nic-plugin` to watch and cleanup NICs
  - Stale NiCs will be deleted in case of rolling the hypervisor node
  - If a `NIC` is manually deleted, it will be recreated by controller

Fixes #714 #590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-driven handling for network interface changes that triggers automatic machine reconciliation.
  * Added event handler registration for plugins and a not-ready signal for deferred NIC processing.

* **Refactor**
  * Replaced polling with informer/watcher-driven NIC monitoring.
  * Simplified attachment/deletion logic to avoid tearing down desired NICs and to better handle no-op reconciliations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->