### PR TITLE
Add IronCore-in-a-Box integration test targets

### DIFF
--- a/.github/workflows/iiab-tests.yml
+++ b/.github/workflows/iiab-tests.yml
@@ -1,0 +1,19 @@
+name: IronCore-in-a-Box Tests
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out libvirt-provider
+        uses: actions/checkout@v6
+      - name: Install test dependencies
+        run: sudo apt-get update && sudo apt-get install -yqq sshpass
+      - name: Run iiab tests
+        run: make iiab-tests

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dev/
 charts/
 apiserver.local.config/
 default.etcd/
+
+# IronCore-in-a-Box integration tests
+.iiab/

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,16 @@ test: manifests generate fmt vet envtest ## Run tests. Some test depend on Linux
 integration-tests: ## Run integration tests against code. For dependencies, refer to the integration-test workflow.
 	go run github.com/onsi/ginkgo/v2/ginkgo run -r --label-filter="integration" -coverprofile cover.out
 
+##@ IronCore-in-a-Box Integration Tests
+
+.PHONY: iiab-tests
+iiab-tests: ## Run ironcore-in-a-box integration tests with local libvirt-provider
+	hack/iiab-tests.sh all
+
+.PHONY: iiab-clean
+iiab-clean: ## Remove iiab clone and kind cluster
+	hack/iiab-tests.sh clean
+
 ##@ Documentation
 
 .PHONY: start-docs

--- a/hack/iiab-tests.sh
+++ b/hack/iiab-tests.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IIAB_DIR="${IIAB_DIR:-${REPO_ROOT}/.iiab}"
+IIAB_REPO="${IIAB_REPO:-https://github.com/ironcore-dev/ironcore-in-a-box.git}"
+IIAB_IMG="${IIAB_IMG:-libvirt-provider:local}"
+IIAB_CLUSTER_NAME="${IIAB_CLUSTER_NAME:-ironcore-in-a-box}"
+CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
+
+clone() {
+    echo "==> Cloning/updating ironcore-in-a-box..."
+    if [ -d "${IIAB_DIR}" ]; then
+        cd "${IIAB_DIR}" && git pull && git submodule update --init --recursive
+    else
+        git clone --recurse-submodules "${IIAB_REPO}" "${IIAB_DIR}"
+    fi
+}
+
+build() {
+    echo "==> Building libvirt-provider image..."
+    ${CONTAINER_TOOL} build -t "${IIAB_IMG}" "${REPO_ROOT}"
+}
+
+patch() {
+    echo "==> Patching iiab kustomization..."
+    local kustomization="${IIAB_DIR}/base/libvirt-provider/kustomization.yaml"
+    local kustomization_dir
+    kustomization_dir="$(cd "$(dirname "${kustomization}")" && pwd)"
+    local config_path
+    config_path="$(python3 -c "import os.path; print(os.path.relpath('${REPO_ROOT}/config/default', '${kustomization_dir}'))")"
+
+    # Reset any previous patches by restoring from git
+    cd "${IIAB_DIR}" && git checkout -- base/libvirt-provider/kustomization.yaml && cd "${REPO_ROOT}"
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "s|github.com/ironcore-dev/libvirt-provider/config/default?ref=.*|${config_path}|" "${kustomization}"
+        sed -i '' "s|newName: ghcr.io/ironcore-dev/libvirt-provider|newName: libvirt-provider|" "${kustomization}"
+        sed -i '' "/newName: libvirt-provider/{n;s|newTag:.*|newTag: local|;}" "${kustomization}"
+    else
+        sed -i "s|github.com/ironcore-dev/libvirt-provider/config/default?ref=.*|${config_path}|" "${kustomization}"
+        sed -i "s|newName: ghcr.io/ironcore-dev/libvirt-provider|newName: libvirt-provider|" "${kustomization}"
+        sed -i "/newName: libvirt-provider/{n;s|newTag:.*|newTag: local|;}" "${kustomization}"
+    fi
+
+    echo "    Patched to use config from: ${config_path}"
+    echo "    Patched to use image: ${IIAB_IMG}"
+}
+
+deploy() {
+    echo "==> Building kind node image..."
+    ${CONTAINER_TOOL} build -t ironcore-dev/kind-node:local "${IIAB_DIR}"
+
+    echo "==> Deleting existing kind cluster (if any)..."
+    kind delete cluster --name "${IIAB_CLUSTER_NAME}" 2>/dev/null || true
+
+    echo "==> Deploying ironcore stack..."
+    make -C "${IIAB_DIR}" prepare ironcore ironcore-net apinetlet setup-network metalnetlet KIND_IMAGE=ironcore-dev/kind-node:local
+
+    echo "==> Loading libvirt-provider image into kind cluster..."
+    kind load docker-image "${IIAB_IMG}" --name "${IIAB_CLUSTER_NAME}"
+
+    echo "==> Deploying libvirt-provider..."
+    make -C "${IIAB_DIR}" libvirt-provider
+}
+
+run_tests() {
+    echo "==> Running tests..."
+    make -C "${IIAB_DIR}" test
+}
+
+clean() {
+    echo "==> Cleaning up..."
+    kind delete cluster --name "${IIAB_CLUSTER_NAME}" || true
+    rm -rf "${IIAB_DIR}"
+}
+
+usage() {
+    echo "Usage: $0 {all|clone|build|patch|deploy|test|clean}"
+    echo ""
+    echo "Commands:"
+    echo "  all     Run the full iiab test flow (clone, build, patch, deploy, test)"
+    echo "  clone   Clone or update ironcore-in-a-box"
+    echo "  build   Build the local libvirt-provider Docker image"
+    echo "  patch   Patch iiab kustomization to use local image and configs"
+    echo "  deploy  Deploy the full ironcore stack with local libvirt-provider"
+    echo "  test    Run iiab lint and tests"
+    echo "  clean   Delete kind cluster and remove iiab clone"
+    echo ""
+    echo "Environment variables:"
+    echo "  IIAB_DIR            Directory to clone iiab into (default: .iiab)"
+    echo "  IIAB_REPO           Git URL for iiab (default: github.com/ironcore-dev/ironcore-in-a-box)"
+    echo "  IIAB_IMG            Docker image tag (default: libvirt-provider:local)"
+    echo "  IIAB_CLUSTER_NAME   Kind cluster name (default: ironcore-in-a-box)"
+    echo "  CONTAINER_TOOL      Container runtime (default: docker)"
+}
+
+case "${1:-all}" in
+    all)
+        clone
+        build
+        patch
+        deploy
+        run_tests
+        ;;
+    clone)   clone ;;
+    build)   build ;;
+    patch)   patch ;;
+    deploy)  deploy ;;
+    test)    run_tests ;;
+    clean)   clean ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        echo "Unknown command: $1"
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Verify current libvirt-provider changes with ironcore-in-a-box test target. Can be run locally on Mac and
runs also in GitHub Actions on Ubuntu.

Fixes #719 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Established automated integration testing infrastructure with CI/CD pipeline integration
  * Added testing and environment cleanup automation utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->