### PR TITLE
Add IronCore-in-a-Box integration test targets

### DIFF
--- a/.github/workflows/iiab-tests.yml
+++ b/.github/workflows/iiab-tests.yml
@@ -1,0 +1,19 @@
+name: IronCore-in-a-Box Tests
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out libvirt-provider
+        uses: actions/checkout@v6
+      - name: Install test dependencies
+        run: sudo apt-get update && sudo apt-get install -yqq sshpass
+      - name: Run iiab tests
+        run: make iiab-tests IIAB_BRANCH=enh/allow-image-and-config-overwrites2

--- a/.github/workflows/iiab-tests.yml
+++ b/.github/workflows/iiab-tests.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Install test dependencies
         run: sudo apt-get update && sudo apt-get install -yqq sshpass
       - name: Run iiab tests
-        run: make iiab-tests IIAB_BRANCH=enh/allow-image-and-config-overwrites2
+        run: make iiab-tests

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dev/
 charts/
 apiserver.local.config/
 default.etcd/
+
+# IronCore-in-a-Box integration tests
+.iiab/

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,25 @@ test: manifests generate fmt vet envtest ## Run tests. Some test depend on Linux
 integration-tests: ## Run integration tests against code. For dependencies, refer to the integration-test workflow.
 	go run github.com/onsi/ginkgo/v2/ginkgo run -r --label-filter="integration" -coverprofile cover.out
 
+##@ IronCore-in-a-Box Integration Tests
+
+IIAB_BRANCH ?= main
+IIAB_KIND_CLUSTER_NAME ?= iiab-libvirt-provider-test
+export IIAB_BRANCH
+export KIND_CLUSTER_NAME := $(IIAB_KIND_CLUSTER_NAME)
+
+.PHONY: iiab-tests
+iiab-tests: ## Run ironcore-in-a-box integration tests with local libvirt-provider
+	hack/iiab-tests.sh
+
+.PHONY: iiab-tests-local
+iiab-tests-local: ## Run iiab tests against a local checkout (usage: make iiab-tests-local IIAB_DIR=../ironcore-in-a-box)
+	IIAB_LOCAL=1 hack/iiab-tests.sh
+
+.PHONY: iiab-clean
+iiab-clean: ## Delete the iiab test kind cluster and remove cloned directory
+	hack/iiab-tests.sh clean
+
 ##@ Documentation
 
 .PHONY: start-docs

--- a/hack/iiab-tests.sh
+++ b/hack/iiab-tests.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IIAB_DIR="${IIAB_DIR:-${REPO_ROOT}/.iiab}"
+IIAB_REPO="${IIAB_REPO:-https://github.com/ironcore-dev/ironcore-in-a-box.git}"
+IIAB_BRANCH="${IIAB_BRANCH:-main}"
+IIAB_LOCAL="${IIAB_LOCAL:-}"
+CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-iiab-libvirt-provider-test}"
+
+LIBVIRT_PROVIDER_CONFIG_DIR="${REPO_ROOT}/config/default"
+LIBVIRT_PROVIDER_IMAGE_TAG="local"
+
+clean() {
+    echo "==> Deleting kind cluster '${KIND_CLUSTER_NAME}'..."
+    kind delete cluster --name "${KIND_CLUSTER_NAME}" 2>/dev/null || true
+    if [ -n "${IIAB_LOCAL}" ]; then
+        echo "    IIAB_LOCAL is set, keeping ${IIAB_DIR}"
+    else
+        echo "==> Removing ${IIAB_DIR}..."
+        rm -rf "${IIAB_DIR}"
+    fi
+}
+
+if [ "${1:-}" = "clean" ]; then
+    clean
+    exit 0
+fi
+
+if [ -n "${IIAB_LOCAL}" ]; then
+    echo "==> Using local ironcore-in-a-box at ${IIAB_DIR}"
+    if [ ! -d "${IIAB_DIR}" ]; then
+        echo "ERROR: IIAB_LOCAL is set but ${IIAB_DIR} does not exist" >&2
+        exit 1
+    fi
+else
+    echo "==> Cloning/updating ironcore-in-a-box (branch: ${IIAB_BRANCH})..."
+    if [ -d "${IIAB_DIR}" ]; then
+        cd "${IIAB_DIR}" && git fetch && git checkout "${IIAB_BRANCH}" && git pull && git submodule update --init --recursive
+    else
+        git clone --recurse-submodules --branch "${IIAB_BRANCH}" "${IIAB_REPO}" "${IIAB_DIR}"
+    fi
+fi
+
+echo "==> Building libvirt-provider image..."
+${CONTAINER_TOOL} build -t "ghcr.io/ironcore-dev/libvirt-provider:${LIBVIRT_PROVIDER_IMAGE_TAG}" "${REPO_ROOT}"
+
+cd "${IIAB_DIR}"
+
+echo "==> Cleaning up any existing test cluster '${KIND_CLUSTER_NAME}'..."
+kind delete cluster --name "${KIND_CLUSTER_NAME}" 2>/dev/null || true
+
+echo "==> Running tests..."
+make test \
+    KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME}" \
+    LIBVIRT_PROVIDER_CONFIG_DIR="${LIBVIRT_PROVIDER_CONFIG_DIR}" \
+    LIBVIRT_PROVIDER_IMAGE_TAG="${LIBVIRT_PROVIDER_IMAGE_TAG}"


### PR DESCRIPTION
# Proposed Changes

Introduce `make iiab-tests` which clones ironcore-in-a-box, builds a local libvirt-provider image, and runs the iiab test suite using the native LIBVIRT_PROVIDER_CONFIG_DIR / LIBVIRT_PROVIDER_IMAGE_TAG overlay support. IIAB_BRANCH is configurable for coordinated cross-repo work.

Use a separate kind cluster (iiab-libvirt-provider-test) to avoid conflicting with an existing ironcore-in-a-box dev cluster. Add IIAB_LOCAL flag to skip git operations and preserve the directory on clean. Add iiab-tests-local Makefile target for local checkouts.

Contributes to #719 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated CI workflow that runs on pull requests.
  * Added integration test targets and a test runner supporting local and remote test execution modes.

* **Chores**
  * Updated project make targets and exported test configuration variables.
  * Updated ignore patterns to exclude test artifacts and local test directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/libvirt-provider/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->