### PR TITLE
Grant RBAC for events in events.k8s.io API group

### DIFF
--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -6,6 +6,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:


### PR DESCRIPTION
The machinepoollet (linked from ironcore) and any reconciler that uses controller-runtime v0.23+ now emits events through the new EventRecorder which writes to the events.k8s.io/v1 API. Without this rule the apiserver rejects every event with:

  events.events.k8s.io "..." is forbidden: User
  "system:serviceaccount:libvirt-provider:libvirt-provider-controller-manager"
  cannot patch resource "events" in API group "events.k8s.io"

Mirror what controller-gen produces in ironcore upstream by listing both API groups ("" and events.k8s.io) on the existing events rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with event-related operations, helping the app handle event updates more reliably across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->