### PR TITLE
Use native filtering of `store.Store`

### DIFF
--- a/api/machine.go
+++ b/api/machine.go
@@ -11,6 +11,33 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const (
+	MachineSpecHasGpuField      = "spec.hasGpu"
+	MachineMetadataDeletedField = "metadata.deleted"
+	MachineSpecImageField       = "spec.image"
+)
+
+func SetupMachineSpecHasGpuFieldIndexer(m *Machine) string {
+	if len(m.Spec.Gpu) > 0 {
+		return "true"
+	}
+	return "false"
+}
+
+func SetupMachineMetadataDeletedFieldIndexer(m *Machine) string {
+	if m.DeletedAt != nil {
+		return "true"
+	}
+	return "false"
+}
+
+func SetupMachineSpecImageFieldIndexer(m *Machine) string {
+	if img := HasBootImage(m); img != nil {
+		return *img
+	}
+	return ""
+}
+
 type Machine struct {
 	apiutils.Metadata `json:"metadata,omitempty"`
 

--- a/api/machine.go
+++ b/api/machine.go
@@ -12,17 +12,9 @@ import (
 )
 
 const (
-	MachineSpecHasGpuField      = "spec.hasGpu"
 	MachineMetadataDeletedField = "metadata.deleted"
 	MachineSpecImageField       = "spec.image"
 )
-
-func SetupMachineSpecHasGpuFieldIndexer(m *Machine) string {
-	if len(m.Spec.Gpu) > 0 {
-		return "true"
-	}
-	return "false"
-}
 
 func SetupMachineMetadataDeletedFieldIndexer(m *Machine) string {
 	if m.DeletedAt != nil {

--- a/cmd/libvirt-provider/app/app.go
+++ b/cmd/libvirt-provider/app/app.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	claim "github.com/ironcore-dev/provider-utils/claimutils/claim"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
 
 	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/ironcore-image/oci/remote"
@@ -296,6 +297,10 @@ func Run(ctx context.Context, opts Options) error {
 		NewFunc:        func() *api.Machine { return &api.Machine{} },
 		CreateStrategy: strategy.MachineStrategy,
 		Dir:            providerHost.MachineStoreDir(),
+		FieldIndexers: map[string]store.IndexerFunc[*api.Machine]{
+			api.MachineMetadataDeletedField: api.SetupMachineMetadataDeletedFieldIndexer,
+			api.MachineSpecImageField:       api.SetupMachineSpecImageFieldIndexer,
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "failed to initialize machine store")

--- a/cmd/libvirt-provider/app/app.go
+++ b/cmd/libvirt-provider/app/app.go
@@ -301,6 +301,7 @@ func Run(ctx context.Context, opts Options) error {
 			api.MachineMetadataDeletedField: api.SetupMachineMetadataDeletedFieldIndexer,
 			api.MachineSpecImageField:       api.SetupMachineSpecImageFieldIndexer,
 		},
+		Log: log.WithName("machine-store"),
 	})
 	if err != nil {
 		setupLog.Error(err, "failed to initialize machine store")

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ironcore-dev/ironcore v0.4.3
 	github.com/ironcore-dev/ironcore-image v0.5.0
 	github.com/ironcore-dev/ironcore-net v0.4.2
-	github.com/ironcore-dev/provider-utils v0.0.0-20260706064412-a5700fe459b6
+	github.com/ironcore-dev/provider-utils v0.0.0-20260806131116-2fea71480579
 	github.com/moby/term v0.5.2
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
@@ -40,7 +40,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/containerd/containerd v1.7.33 // indirect
+	github.com/containerd/containerd v1.7.34 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
-github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
-github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
+github.com/containerd/containerd v1.7.34 h1:Q35B4FUECxcoaMz9QrOlqp+0s72w8/0NWawVMhVdf5g=
+github.com/containerd/containerd v1.7.34/go.mod h1:ozI//0TomTCLPhQREnx0IXDIQMg+Fk7yTtg9fNvU8EQ=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -146,8 +146,10 @@ github.com/ironcore-dev/ironcore-image v0.5.0 h1:L4ZLIV5WhOFk4Bp+PtBXut6nYXsCRAo
 github.com/ironcore-dev/ironcore-image v0.5.0/go.mod h1:seDdoS2K31VpL4LlKC9apbLs2fbGrHZEsPBR3dBYMs0=
 github.com/ironcore-dev/ironcore-net v0.4.2 h1:/3JgoAKFXVwGnoPYipOKO1q81SJK0ekrbqPxf56n1Tk=
 github.com/ironcore-dev/ironcore-net v0.4.2/go.mod h1:xggjzKMw0+Xn9u8aSQ8+m7Fw6DXB/Qx3v+1rao0dG7w=
-github.com/ironcore-dev/provider-utils v0.0.0-20260706064412-a5700fe459b6 h1:pdg6esPunmxzig5Vh9fU3PELRVhkihsOMVLeRDRgP1U=
-github.com/ironcore-dev/provider-utils v0.0.0-20260706064412-a5700fe459b6/go.mod h1:8RVoVQCuxRxWtSXiIKB70U0SHrxFuGXNbvQoibk5jY8=
+github.com/ironcore-dev/provider-utils v0.0.0-20260803154836-aa1a26a81358 h1:+J6raAe+3GTyWauSBXswN1y0zNTtAhnlOvAcpc0XecQ=
+github.com/ironcore-dev/provider-utils v0.0.0-20260803154836-aa1a26a81358/go.mod h1:TUyzkOPkf9sfvpHdxGqmHVgXPlF9lrHMomlqGgqa9mE=
+github.com/ironcore-dev/provider-utils v0.0.0-20260806131116-2fea71480579 h1:WwkGpVfDMRH5nm5FoPhIR6tDluFTnCI67VCQmCP89dk=
+github.com/ironcore-dev/provider-utils v0.0.0-20260806131116-2fea71480579/go.mod h1:TUyzkOPkf9sfvpHdxGqmHVgXPlF9lrHMomlqGgqa9mE=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/controllers/controllers_suite_test.go
+++ b/internal/controllers/controllers_suite_test.go
@@ -118,6 +118,10 @@ var _ = BeforeSuite(func() {
 		NewFunc:        func() *api.Machine { return &api.Machine{} },
 		CreateStrategy: strategy.MachineStrategy,
 		Dir:            providerHost.MachineStoreDir(),
+		FieldIndexers: map[string]store.IndexerFunc[*api.Machine]{
+			api.MachineMetadataDeletedField: api.SetupMachineMetadataDeletedFieldIndexer,
+			api.MachineSpecImageField:       api.SetupMachineSpecImageFieldIndexer,
+		},
 	})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controllers/machine_controller.go
+++ b/internal/controllers/machine_controller.go
@@ -157,18 +157,16 @@ func (r *MachineReconciler) Start(ctx context.Context) error {
 
 	r.imageCache.AddListener(ociutils.ListenerFuncs{
 		HandlePullDoneFunc: func(evt ociutils.PullDoneEvent) {
-			machines, err := r.machines.List(ctx)
+			machines, err := r.machines.List(ctx, store.MatchingFields{api.MachineSpecImageField: evt.Ref})
 			if err != nil {
 				log.Error(err, "failed to list machine")
 				return
 			}
 
 			for _, machine := range machines {
-				if api.IsImageReferenced(machine, evt.Ref) {
-					r.eventRecorder.Eventf(machine.Metadata, corev1.EventTypeNormal, "ImagePullSucceeded", "PullImage", "Pulled image %s", evt.Ref)
-					log.V(1).Info("Image pulled: Requeue machines", "Image", evt.Ref, "Machine", machine.ID)
-					r.queue.Add(machine.ID)
-				}
+				r.eventRecorder.Eventf(machine.Metadata, corev1.EventTypeNormal, "ImagePullSucceeded", "PullImage", "Pulled image %s", evt.Ref)
+				log.V(1).Info("Image pulled: Requeue machines", "Image", evt.Ref, "Machine", machine.ID)
+				r.queue.Add(machine.ID)
 			}
 		},
 	})
@@ -262,14 +260,14 @@ func (r *MachineReconciler) startEnqueueMachineByLibvirtEvent(ctx context.Contex
 func (r *MachineReconciler) startGarbageCollector(ctx context.Context, log logr.Logger) {
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		log.V(1).Info("starting garbage-collector loop")
-		machines, err := r.machines.List(ctx)
+		machines, err := r.machines.List(ctx, store.MatchingFields{api.MachineMetadataDeletedField: "true"})
 		if err != nil {
 			log.Error(err, "failed to list machines")
 			return
 		}
 
 		for _, machine := range machines {
-			if !slices.Contains(machine.Finalizers, MachineFinalizer) || machine.DeletedAt == nil {
+			if !slices.Contains(machine.Finalizers, MachineFinalizer) {
 				continue
 			}
 

--- a/internal/server/machine_list.go
+++ b/internal/server/machine_list.go
@@ -32,17 +32,13 @@ func (s *Server) getLibvirtMachine(ctx context.Context, id string) (*api.Machine
 }
 
 func (s *Server) listMachines(ctx context.Context, log logr.Logger) ([]*iri.Machine, error) {
-	machines, err := s.machineStore.List(ctx)
+	machines, err := s.machineStore.List(ctx, store.MatchingLabels{api.ManagerLabel: api.MachineManager})
 	if err != nil {
 		return nil, fmt.Errorf("error listing machines: %w", err)
 	}
 
 	var res []*iri.Machine
 	for _, machine := range machines {
-		if !api.IsManagedBy(machine, api.MachineManager) {
-			continue
-		}
-
 		iriMachine, err := s.convertMachineToIRIMachine(ctx, log, machine)
 		if err != nil {
 			return nil, err

--- a/internal/server/server_suite_test.go
+++ b/internal/server/server_suite_test.go
@@ -110,6 +110,10 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		NewFunc:        func() *api.Machine { return &api.Machine{} },
 		CreateStrategy: strategy.MachineStrategy,
 		Dir:            providerHost.MachineStoreDir(),
+		FieldIndexers: map[string]store.IndexerFunc[*api.Machine]{
+			api.MachineMetadataDeletedField: api.SetupMachineMetadataDeletedFieldIndexer,
+			api.MachineSpecImageField:       api.SetupMachineSpecImageFieldIndexer,
+		},
 	})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/utils/claims_test.go
+++ b/internal/utils/claims_test.go
@@ -12,6 +12,7 @@ import (
 	apiutils "github.com/ironcore-dev/provider-utils/apiutils/api"
 	"github.com/ironcore-dev/provider-utils/claimutils/pci"
 	hostutils "github.com/ironcore-dev/provider-utils/storeutils/host"
+	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -25,6 +26,10 @@ var _ = Describe("Claims Utils", func() {
 				NewFunc:        func() *api.Machine { return &api.Machine{} },
 				CreateStrategy: strategy.MachineStrategy,
 				Dir:            filepath.Join(tempDir, "store", "machines"),
+				FieldIndexers: map[string]store.IndexerFunc[*api.Machine]{
+					api.MachineMetadataDeletedField: api.SetupMachineMetadataDeletedFieldIndexer,
+					api.MachineSpecImageField:       api.SetupMachineSpecImageFieldIndexer,
+				},
 			})
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
# Proposed Changes

- Use `MatchingLabels` an `MatchingFields` filters for listing instead of post-fetch loops


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved machine lookups during image handling and garbage collection by filtering results at the store level.
  * Limited machine listings to provider-managed machines for more efficient responses.

* **Bug Fixes**
  * Improved filtering of deleted machines and machines associated with specific images.

* **Tests**
  * Updated test coverage and setup to support the enhanced machine filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->