### PR TITLE
Update release-drafter for contributions from forks

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,35 +1,37 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
       - release-**
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
-  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   update_release_draft:
     name: Run release drafter
+    if: github.event_name != 'pull_request_target'
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Labels PRs based on branch, title, files, and body patterns
-      - uses: release-drafter/release-drafter/autolabeler@v7
-        if: github.event_name == 'pull_request'
-        with:
-          config-name: release-drafter.yml
-          token: ${{ secrets.GITHUB_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       # or a release branch
       - uses: release-drafter/release-drafter@v7
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
-          config-name: release-drafter.yml
+          commitish: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
+  auto_label:
+    name: Run autolabeler
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7


### PR DESCRIPTION
Add `pull_request_target` trigger and split workflow into two dedicated
jobs for `autolabeler` and `release_drafter`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release draft generation and pull request labeling workflows.
  * Updated workflow permissions for more controlled access.
  * Ensured release drafts use the current branch reference consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->